### PR TITLE
Moving nob_minimal_log_level to avoid redefinition

### DIFF
--- a/nob.h
+++ b/nob.h
@@ -1,4 +1,4 @@
-/* nob - v1.3.0 - Public Domain - https://github.com/tsoding/nob
+/* nob - v1.3.1 - Public Domain - https://github.com/tsoding/nob
 
    This library is the next generation of the [NoBuild](https://github.com/tsoding/nobuild) idea.
 
@@ -1308,6 +1308,7 @@ int closedir(DIR *dirp)
 /*
    Revision history:
 
+      1.3.1 (2024-10-21) Fix redeclaration error for minimal_log_level (By @KillerxDBr)
       1.3.0 (2024-10-17) Add NOB_UNREACHABLE
       1.2.2 (2024-10-16) Fix compilation of nob_cmd_run_sync_and_reset on Windows (By @KillerxDBr)
       1.2.1 (2024-10-16) Add a separate include guard for NOB_STRIP_PREFIX.

--- a/nob.h
+++ b/nob.h
@@ -118,6 +118,9 @@ typedef enum {
     NOB_NO_LOGS,
 } Nob_Log_Level;
 
+// Any messages with the level below nob_minimal_log_level are going to be suppressed.
+extern Nob_Log_Level nob_minimal_log_level;
+
 void nob_log(Nob_Log_Level level, const char *fmt, ...);
 
 // It is an equivalent of shift command from bash. It basically pops an element from

--- a/nob.h
+++ b/nob.h
@@ -118,9 +118,6 @@ typedef enum {
     NOB_NO_LOGS,
 } Nob_Log_Level;
 
-// Any messages with the level below nob_minimal_log_level are going to be suppressed.
-Nob_Log_Level nob_minimal_log_level = NOB_INFO;
-
 void nob_log(Nob_Log_Level level, const char *fmt, ...);
 
 // It is an equivalent of shift command from bash. It basically pops an element from
@@ -435,6 +432,9 @@ static int closedir(DIR *dirp);
 #endif // NOB_H_
 
 #ifdef NOB_IMPLEMENTATION
+
+// Any messages with the level below nob_minimal_log_level are going to be suppressed.
+Nob_Log_Level nob_minimal_log_level = NOB_INFO;
 
 static size_t nob_temp_size = 0;
 static char nob_temp[NOB_TEMP_CAPACITY] = {0};


### PR DESCRIPTION
Moving "nob_minimal_log_level" var to inside of "NOB_IMPLEMENTATION" to avoid redefinitions if included in multiple files

i made the other pr from the wrong branch...