### PR TITLE
added raw link to `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This library is the next generation of the [NoBuild](https://github.com/tsoding/
 # Quick Example
 
 The only file you need from here is [nob.h](./nob.h). Just copy-paste it to your project and start using it.
+Download the raw file here: [nob.h](https://raw.githubusercontent.com/tsoding/nob.h/refs/heads/main/nob.h)
 
 ```c
 // nob.c


### PR DESCRIPTION
This is so people can just copy the link and wget it. Copying the link above it gives you an HTML file.
I could not find a way to make this not depend on the URL of the repository sadly.