### PR TITLE
Include <limits.h> for Linux musl libc

### DIFF
--- a/nob.h
+++ b/nob.h
@@ -1,4 +1,4 @@
-/* nob - v1.5.0 - Public Domain - https://github.com/tsoding/nob
+/* nob - v1.5.1 - Public Domain - https://github.com/tsoding/nob
 
    This library is the next generation of the [NoBuild](https://github.com/tsoding/nobuild) idea.
 
@@ -1375,6 +1375,7 @@ int closedir(DIR *dirp)
 /*
    Revision history:
 
+      1.5.1 (2024-10-25) Include limits.h for Linux musl libc (by @pgalkin)
       1.5.0 (2024-10-23) Add nob_get_current_dir_temp()
                          Add nob_set_current_dir()
       1.4.0 (2024-10-21) Fix UX issues with NOB_GO_REBUILD_URSELF on Windows when you call nob without the .exe extension (By @pgalkin)

--- a/nob.h
+++ b/nob.h
@@ -79,6 +79,7 @@
 #include <string.h>
 #include <errno.h>
 #include <ctype.h>
+#include <limits.h>
 
 #ifdef _WIN32
 #    define WIN32_LEAN_AND_MEAN


### PR DESCRIPTION
On Alpine 3.20 the standard C library is musl and compilation gives an error:
```sh
~/code/nob.h $ clang -o nob nob.c
In file included from nob.c:3:
./nob.h:1176:43: error: use of undeclared identifier 'PATH_MAX'
 1176 |     char *buffer = (char*) nob_temp_alloc(PATH_MAX);
      |                                           ^
./nob.h:1177:24: error: use of undeclared identifier 'PATH_MAX'
 1177 |     if (getcwd(buffer, PATH_MAX) == NULL) {
      |                        ^
2 errors generated
```
I guess on Windows we get this header with `<windows.h>` even with `WIN32_LEAN_AND_MEAN`.

On Debian it is somehow not required, I guess because of glibc.