### PR TITLE
nob.h: jai-style dynamic array for loop macro

### DIFF
--- a/tests/nob_da_for.c
+++ b/tests/nob_da_for.c
@@ -1,0 +1,64 @@
+#define NOB_STRIP_PREFIX
+#define NOB_IMPLEMENTATION
+#include "nob.h"
+
+typedef struct {
+    float x, y, z;
+} Vector3;
+
+typedef struct {
+    Vector3 *items;
+    size_t count;
+    size_t capacity;
+} Various_Vector3s;
+
+
+int main(void)
+{
+    const char *msg = tprintf("Short and Sweet `%s`", "tprintf");
+    nob_log(INFO, "%s", msg);
+
+
+    Nob_Cmd cmd = {0};
+    cmd_append(&cmd, "jai.exe", "--virtual-by-default", "--allow-inheritance", "-Dnocheckin", "--activate-gc", "--enable-template", "first.jai");
+
+#ifndef CC_HAS_TYPEOF_SUPPORT
+
+    nob_log(INFO, "Compiler used has no typeof support. We can't use `it`, only can use `it_index`");
+    da_for(&cmd) {
+        const char* it = cmd.items[it_index];
+        nob_log(INFO, "%d: `%s`", it_index, it);
+    }
+    return 0;
+
+#else
+
+    nob_log(INFO, "Iterating cmd parts");
+    da_for(&cmd) {
+        nob_log(INFO, "%d: `%s`", it_index, it);
+    }
+
+
+    Nob_File_Paths fps = {0};
+    da_append(&fps, "D:\\sokoban");
+    da_append(&fps, "/mnt/d/pfolder");
+
+    nob_log(INFO, "Iterating %d file paths", fps.count);
+    da_for(&fps) {
+        nob_log(INFO, "%d: %s", it_index, it);
+    }
+
+
+    Various_Vector3s vecs = {0};
+    da_append(&vecs, ((Vector3){1.0, 1.1, 1.2}));
+    da_append(&vecs, ((Vector3){2.0, 2.1, 2.2}));
+    da_append(&vecs, ((Vector3){3.0, 3.1, 3.2}));
+
+    nob_log(INFO, "Iterating various %d Vector3s", vecs.count);
+    da_for(&vecs) {
+        nob_log(INFO, "%d: vec3{%.1f, %.1f, %.1f}", it_index, it.x, it.y, it.z, it_index);
+    }
+
+    return 0;
+#endif
+}


### PR DESCRIPTION

## Jai-like `nob` Patch: Introducing `da_for`

Add `da_for` macro for iterating over `nob` dynamic arrays, using similar notation to Jai. The `da_for` is basically foreach with implicit `it`variable and `it_index`, and it scopes them within the loop, so it does not pollute the parent scope. 

Also add ``tprintf`` as a ``NOB_STRIP_PREFIX`` option for ``nob_temp_sprintf``. Not that necessary, just short and sweet to type.

### Example Usage

```c
// NOB_STRIP_PREFIX is enabled otherwise we'd have to use nob_da_for
Nob_File_Paths fps = {0};
da_append(&fps, "D:\\sokoban");
da_append(&fps, "/mnt/d/pfolder");

nob_log(INFO, "Iterating %d file paths", fps.count);
da_for(&fps) {
    nob_log(INFO, "%d: %s", it_index, it);
}
```

### Considerations
``typeof`` is necessary for the nice syntax and we use it with care considering the following.

This implementation checks for compiler support for `typeof`, which has been added in [recent versions of MSVC](https://learn.microsoft.com/en-us/cpp/c-language/typeof-c?view=msvc-170). It also detects if the compiler is `clang-cl.exe`, which supports `typeof`.

GCC, Clang, and MinGW all have support for `typeof`, and I have tested this functionality with these compilers. Even [TCC](https://bellard.org/tcc/tcc-doc.html) seem to support it, although it has not been tested.

In cases where `typeof` is not supported, the `it` variable must be created manually, and only `it_index` will be provided.

A test file was created and added to the tests on ``nob.c``
