### PR TITLE
make the definition of nob_get_current_dir_temp a prototype to appease Clang

### DIFF
--- a/nob.h
+++ b/nob.h
@@ -1526,7 +1526,7 @@ int nob_file_exists(const char *file_path)
 #endif
 }
 
-const char *nob_get_current_dir_temp()
+const char *nob_get_current_dir_temp(void)
 {
 #ifdef _WIN32
     DWORD nBufferLength = GetCurrentDirectory(0, NULL);


### PR DESCRIPTION
The function declaration of `nob_get_current_dir_temp` correctly includes `void` and the definition does not.

I believe this is sufficient as per the standard, however when Including the `nob.h` definition in a source file, Clang interprets this as `nob_get_current_dir_temp` missing its prototype.

Adding in the `void` in the definition as well should be standard compliant and prevent the warning.