### PR TITLE
Go Redefine Urself™ - user configs

### DIFF
--- a/nob.h
+++ b/nob.h
@@ -475,6 +475,7 @@ struct {
 #define NOB_GO_DEFINE(symbol) nob_da_append(&nob_go_defines, #symbol "\0" symbol)
 void nob__go_redefine(const char *source_path, const char *symbol, const char *value);
 #define NOB_GO_REDEFINE(symbol, value) nob__go_redefine(__FILE__, #symbol, value)
+#define NOB_GO_REDEFINE_STR(symbol_string, value) nob__go_redefine(__FILE__, symbol_string, value)
 
 typedef struct {
     size_t count;

--- a/nob.h
+++ b/nob.h
@@ -472,7 +472,8 @@ struct {
     size_t count;
     size_t capacity;
 } nob_go_defines;
-#define NOB_GO_DEFINE(symbol) nob_da_append(&nob_go_defines, #symbol "\0" symbol)
+void nob_go_define(const char* symbol, const char* value);
+#define NOB_GO_DEFINE(symbol) nob_go_define(#symbol, symbol)
 void nob__go_redefine(const char *source_path, const char *symbol, const char *value);
 #define NOB_GO_REDEFINE(symbol, value) nob__go_redefine(__FILE__, #symbol, value)
 #define NOB_GO_REDEFINE_STR(symbol_string, value) nob__go_redefine(__FILE__, symbol_string, value)
@@ -729,6 +730,18 @@ void nob__go_rebuild_urself(const char *source_path, int argc, char **argv, bool
     nob_da_append_many(&cmd, argv, argc);
     if (!nob_cmd_run_sync_and_reset(&cmd)) exit(1);
     exit(0);
+}
+
+void nob_go_define(const char* symbol, const char* value)
+{
+    const size_t slen = strlen(symbol);
+    const size_t vlen = strlen(value);
+    char *def = nob_temp_alloc(slen + vlen + 2);
+    memcpy(def, symbol, slen);
+    def[slen] = 0;
+    memcpy(def + slen + 1, value, vlen);
+    def[slen + 1 + vlen] = 0;
+    nob_da_append(&nob_go_defines, def);
 }
 
 void nob__go_redefine(const char *source_path, const char *symbol, const char *value)


### PR DESCRIPTION
Hack that exploits Go Rebuild Urself™ Technology to support user configs. Demo:
```c
#define NOB_IMPLEMENTATION
#include "nob.h"

#ifndef FOO
#define FOO "default foo"
#endif

#ifndef BAR
#define BAR "default bar"
#endif

int main(int argc, char **argv)
{
   NOB_GO_DEFINE(FOO); 
   NOB_GO_DEFINE(BAR);
   NOB_GO_REBUILD_URSELF(argc, argv);
   for (int i=1; i<argc; ++i) {
      char* arg = argv[i];
      if (strlen(argv[i]) >= 4 && 0 == memcmp(arg, "FOO=", 4)) NOB_GO_REDEFINE(FOO, arg+4);
      if (strlen(argv[i]) >= 4 && 0 == memcmp(arg, "BAR=", 4)) NOB_GO_REDEFINE(BAR, arg+4);
   }
   printf("FOO=[%s] BAR=[%s]\n", FOO, BAR);
}
```
Then `./nob FOO=69` rebuilds with `-DFOO="69"` (or `/DFOO="69"` if cl.exe — not tested) unless already defined as `"69"`. It also works with `./nob FOO=69 BAR=96` but recompiles twice if both values are new. `./nob FOO=69 FOO=96` enters an infinte recompile loop and deletes itself (Go Delete Urself™). 


