### PR TITLE
added nob_da_resize and alias

### DIFF
--- a/nob.h
+++ b/nob.h
@@ -288,6 +288,13 @@ Nob_File_Type nob_get_file_type(const char *path);
         (da)->count += (new_items_count);                                                     \
     } while (0)
 
+#define nob_da_resize(da, new_size)                                                    \
+    do {                                                                               \
+        (da)->capacity = (da)->count = new_size;                                       \
+        (da)->items = NOB_REALLOC((da)->items, (da)->capacity * sizeof(*(da)->items)); \
+        NOB_ASSERT((da)->items != NULL && "Buy more RAM lol");                         \
+    } while (0)
+
 typedef struct {
     char *items;
     size_t count;
@@ -1698,6 +1705,7 @@ int closedir(DIR *dirp)
         #define da_append nob_da_append
         #define da_free nob_da_free
         #define da_append_many nob_da_append_many
+        #define da_resize nob_da_resize
         #define String_Builder Nob_String_Builder
         #define read_entire_file nob_read_entire_file
         #define sb_append_buf nob_sb_append_buf


### PR DESCRIPTION
I found myself needing a resize, for example in a common situation like the following:

```C
vkGetSwapchainImagesKHR(vk_ctx.device, vk_ctx.swapchain.handle, &img_count, NULL);
nob_da_resize(&vk_ctx.swapchain.imgs, img_count);
vkGetSwapchainImagesKHR(vk_ctx.device, vk_ctx.swapchain.handle, &img_count, vk_ctx.swapchain.imgs.items);
```

Essentially, a dynamic array is needed, because you don't know the size until after the query is made. Also, NOB_REALLOC works well, since, rebuilding the swapchain is common. To be clear, count and capacity are set to the new size (I think this is how std::resize works as well).

Thanks for all that you do.