### PR TITLE
Remove if (capacity == 0) branching in da_append(_many)

### DIFF
--- a/nob.h
+++ b/nob.h
@@ -256,12 +256,15 @@ Nob_File_Type nob_get_file_type(const char *path);
 #ifndef NOB_DA_INIT_CAP
 #define NOB_DA_INIT_CAP 256
 #endif
+#ifndef NOB_DA_SCALING_FACTOR
+#define NOB_DA_SCALING_FACTOR 2
+#endif
 
 // Append an item to a dynamic array
 #define nob_da_append(da, item)                                                          \
     do {                                                                                 \
         if ((da)->count >= (da)->capacity) {                                             \
-            (da)->capacity = (da)->capacity == 0 ? NOB_DA_INIT_CAP : (da)->capacity*2;   \
+            (da)->capacity = (NOB_DA_INIT_CAP + (da)->capacity) * NOB_DA_SCALING_FACTOR; \
             (da)->items = NOB_REALLOC((da)->items, (da)->capacity*sizeof(*(da)->items)); \
             NOB_ASSERT((da)->items != NULL && "Buy more RAM lol");                       \
         }                                                                                \
@@ -272,20 +275,16 @@ Nob_File_Type nob_get_file_type(const char *path);
 #define nob_da_free(da) NOB_FREE((da).items)
 
 // Append several items to a dynamic array
-#define nob_da_append_many(da, new_items, new_items_count)                                  \
-    do {                                                                                    \
-        if ((da)->count + (new_items_count) > (da)->capacity) {                               \
-            if ((da)->capacity == 0) {                                                      \
-                (da)->capacity = NOB_DA_INIT_CAP;                                           \
-            }                                                                               \
-            while ((da)->count + (new_items_count) > (da)->capacity) {                        \
-                (da)->capacity *= 2;                                                        \
-            }                                                                               \
-            (da)->items = NOB_REALLOC((da)->items, (da)->capacity*sizeof(*(da)->items)); \
-            NOB_ASSERT((da)->items != NULL && "Buy more RAM lol");                          \
-        }                                                                                   \
+#define nob_da_append_many(da, new_items, new_items_count)                                      \
+    do {                                                                                        \
+        if ((da)->count + (new_items_count) > (da)->capacity) {                                 \
+			(da)->capacity = new_items_count                                                    \
+				+ ((NOB_DA_INIT_CAP + (da)->capacity) * NOB_DA_SCALING_FACTOR);                 \
+            (da)->items = NOB_REALLOC((da)->items, (da)->capacity*sizeof(*(da)->items));        \
+            NOB_ASSERT((da)->items != NULL && "Buy more RAM lol");                              \
+        }                                                                                       \
         memcpy((da)->items + (da)->count, (new_items), (new_items_count)*sizeof(*(da)->items)); \
-        (da)->count += (new_items_count);                                                     \
+        (da)->count += (new_items_count);                                                       \
     } while (0)
 
 typedef struct {


### PR DESCRIPTION
Removing (unnecessary) branch/checking for 0 by creating a scaling calculation on resize, essentially doing n + current_capacity * scaling factor.
Simplifying logic.
Without ever using da_append_many ( where n_m is current_capacity and n0 == n_m), the scaling is essentially 4n for i > 1, where n == NOB_DA_INIT_CAP

The current init of 256 and scaling factor of 2 may not be optimal, FOLLY (Facebook standard library) uses a scaling factor for dynamic arrays of 1.4, which more aligned with their data. Initial capacity of 64 might be better for general use cases. 

Reserved to macros so they can be redefined by user.

The normal scaling factor is kept because setting macros to be non-implicit convertible (such as fractions) will wreck havoc with -Wconversion flag, and lots of casts are needed to suppress those warnings.

There is also the ability to use a C23 compatible macro which can do casting with typeof operator, which may be good in future. If that is something you would like to see, let me know. I suspect caring about these pedantic thing is more in line of "pesky Rust developers". :⁾