### PR TITLE
Fix broken link at the top of nob.h

### DIFF
--- a/nob.h
+++ b/nob.h
@@ -1,4 +1,4 @@
-/* nob - v1.10.0-dev - Public Domain - https://github.com/tsoding/nob
+/* nob - v1.10.0-dev - Public Domain - https://github.com/tsoding/nob.h
 
    This library is the next generation of the [NoBuild](https://github.com/tsoding/nobuild) idea.
 


### PR DESCRIPTION
The link https://github.com/tsoding/nob doesn't work, so when someone uses nob in their project, other people won't be able to see where to find it themselves.
The only change in this pull request is to add `.h` to the end of the link, so it actually leads to this repository.