### PR TITLE
Fix reported zizmor security issues

### DIFF
--- a/.github/workflows/nob.yaml
+++ b/.github/workflows/nob.yaml
@@ -1,12 +1,16 @@
 name: no-build build
 on: [push, pull_request]
 
+permissions: {}
+
 jobs:
   macos:
     runs-on: macos-latest
     steps:
       - name: Clone GIT repo
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Build nob
         run: clang -o nob nob.c
       - name: Run nob
@@ -19,6 +23,8 @@ jobs:
     steps:
       - name: Clone GIT repo
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Build nob
         run: ${{ matrix.cc }} -o nob nob.c
       - name: Run nob
@@ -28,6 +34,8 @@ jobs:
     steps:
       - name: Clone GIT repo
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Build nob
         shell: cmd
         # cl.exe isn't available as-is in Github images because they don't want

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+ci:
+  autoupdate_schedule: quarterly
+  submodules: false
+
+repos:
+  - repo: https://github.com/woodruffw/zizmor-pre-commit
+    rev: v1.3.0
+    hooks:
+      - id: zizmor


### PR DESCRIPTION
In this pull request, we remove excessive permissions from the Github Actions runners as reported by [zizmor](https://github.com/woodruffw/zizmor). zizmor is a static analysis tool for GitHub Actions, their README page has much more information.

To find future issues if they were to be introduced, I added the [zizmor pre-commit hook](https://github.com/woodruffw/zizmor-pre-commit). [pre-commit](https://pre-commit.com/) is a multi-language package manager for pre-commit hooks. Their website has a lot more information, including how to get it set up to run on your local machine.

I also added basic configuration to support running [pre-commit.ci](https://pre-commit.ci/) so new pull requests are checked by this pre-commit hook if desired, but without being authorized to run it is inert.