### PR TITLE
feat: implementation of j flag

### DIFF
--- a/tests/procs_j3.c
+++ b/tests/procs_j3.c
@@ -1,0 +1,19 @@
+#define NOB_IMPLEMENTATION
+#include "nob.h"
+
+int main(void)
+{
+    Nob_Cmd cmd = {0};
+
+    Nob_Procs procs = {0};
+    nob_da_resize(&procs, 3);
+    procs.count = 0;
+
+    for (size_t i = 0; i < 10; ++i) {
+        nob_cmd_append(&cmd, "echo", nob_temp_sprintf("running %d-nth command", i));
+        nob_procs_append_or_wait_and_reset(&procs, nob_cmd_run_async_and_reset(&cmd));
+    }
+    if (!nob_procs_wait_and_reset(&procs)) return 1;
+
+    return 0;
+}


### PR DESCRIPTION
Kinda works like '-j' flags. Had this idea while watching [olive.c porting to nob.h](https://www.youtube.com/watch?v=D1bsg8wkZzo&t=6641s) video.
Basically whenever we add new proc to `Nob_Procs` we can wait previous processes to finish if we have reached threads cap.

Now instead of
```c
    size_t thread_count = 6;
    for (size_t i = 0; i < ARRAY_LEN(names); ++i) {
        nob_da_append(procs, build_something_a(names[I]));
        nob_da_append(procs, build_something_b(names[I]));
        nob_da_append(procs, build_something_c(names[I]));
        if (procs->count >= thread_count) {
            if (!nob_procs_wait_and_reset(procs)) return false;
        }
    }
    if (!nob_procs_wait_and_reset(procs)) return false;
```
it can be
```c
    nob_da_resize(procs, 6);
    procs->count = 0;
    for (size_t i = 0; i < ARRAY_LEN(names); ++i) {
        nob_procs_append_or_wait_and_reset(procs, build_something_a(names[I]));
        nob_procs_append_or_wait_and_reset(procs, build_something_b(names[I]));
        nob_procs_append_or_wait_and_reset(procs, build_something_c(names[I]));
    }
    if (!nob_procs_wait_and_reset(procs)) return false;
```
Difference is that it will build all the demos it can before failing and will run only specific number of processes (which wasn't possible with `procs->count >= thread_count` outside of `build_vc_demo`)