### PR TITLE
Bootstrap build system without invoking the compiler manually

### DIFF
--- a/how_to/001_basic_usage/nob.c
+++ b/how_to/001_basic_usage/nob.c
@@ -1,3 +1,6 @@
+//bin/false; cc nob.c -Wall -Wextra -o nob; exit
+// ^ This line will make the build script act as a shell script when made executable with `chmod +x nob.c`.
+
 // This is your build script. You only need to "bootstrap" it once with `cc -o nob nob.c` (you can
 // call it whatever actually) or `cl nob.c` on MSVC and thanks to NOB_GO_REBUILD_URSELF (see below).
 // After that every time you run the `nob` executable if it detects that you modifed nob.c it will

--- a/nob.c
+++ b/nob.c
@@ -1,3 +1,5 @@
+//bin/false; cc nob.c -Wall -Wextra -o nob; exit
+
 #define NOB_IMPLEMENTATION
 #define NOB_STRIP_PREFIX
 #define NOB_EXPERIMENTAL_DELETE_OLD


### PR DESCRIPTION
GO_BOOTSTRAP_URSELF Technology™:

The build system can be bootstrapped by making the build script executable via `chmod +x nob.c`, which will make the build script [act like a shell script](https://en.wikipedia.org/wiki/Polyglot_(computing)), invoking the compiler on itself. 

I think this is useful, as its convenient and less error-prone than invoking the compiler manually.
It also allows you to always compile with warnings and possibly other flags, which you might have otherwise forgotten.