### PR TITLE
closes issue nob_read_entire_file

### DIFF
--- a/nob.h
+++ b/nob.h
@@ -1403,7 +1403,11 @@ bool nob_read_entire_file(const char *path, Nob_String_Builder *sb)
     FILE *f = fopen(path, "rb");
     if (f == NULL)                 nob_return_defer(false);
     if (fseek(f, 0, SEEK_END) < 0) nob_return_defer(false);
+#ifndef _WIN32
     long m = ftell(f);
+#else
+    long long m = _ftelli64(f);
+#endif
     if (m < 0)                     nob_return_defer(false);
     if (fseek(f, 0, SEEK_SET) < 0) nob_return_defer(false);
 


### PR DESCRIPTION
This PR will close issue https://github.com/tsoding/nob.h/issues/33, in which `nob_read_entire_file` did not work for the target windows when the file size was greater than 2GB. Thanks to @KillerxDBr for the solution.