### PR TITLE
Add Defer Functionality for Resource Cleanup

### DIFF
--- a/nob.c
+++ b/nob.c
@@ -19,6 +19,7 @@ const char *test_names[] = {
     "da_append",
     "sb_appendf",
     "da_foreach",
+    "defer",
 };
 #define test_names_count ARRAY_LEN(test_names)
 

--- a/tests/defer.c
+++ b/tests/defer.c
@@ -1,0 +1,43 @@
+#define NOB_IMPLEMENTATION
+#include "nob.h"
+
+static void cleanup1(void* arg) {
+    (void)arg;  // Unused
+    nob_log(NOB_INFO, "Cleanup 1 executed");
+}
+
+static void cleanup2(void* arg) {
+    (void)arg;  // Unused
+    nob_log(NOB_INFO, "Cleanup 2 executed");
+}
+
+void test_basic_defer(void) {
+    
+    int dummy = 0;
+    nob_defer(cleanup1, &dummy);
+    nob_log(NOB_INFO, "First defer registered");
+    
+    {  // Testing nested scope
+        int dummy2 = 0;
+        nob_defer(cleanup2, &dummy2);
+        nob_log(NOB_INFO, "Second defer registered in nested scope");
+    }  // cleanup2 should execute here
+}  // cleanup1 should execute here
+
+void test_basic_memory(void) {
+    void* ptr = malloc(100);
+    if (!ptr) {
+        nob_log(NOB_ERROR, "Memory allocation failed");
+        return;
+    }
+    nob_defer_free(ptr);
+
+    memset(ptr, 0, 100);
+    nob_log(NOB_INFO, "Basic memory test completed");
+}
+
+int main(void) {
+    test_basic_defer();
+    test_basic_memory();
+    return 0;
+}


### PR DESCRIPTION
This PR introduces a defer-style resource cleanup mechanism to nob.h, inspired by C3's `defer` statement. It provides a simple way to ensure resources are properly freed when leaving a scope. I implemented a standalone version of this as [defer.h](https://github.com/maddeye/defer.h), which tests many different scenarios and edge cases. Hope you find a liking in this.

## Example Usage
```c
#include <stdio.h>
#define NOB_IMPLEMENTATION
#include "nob.h"

void print_message(void* arg) {
    printf("Cleanup: %s\n", (char*)arg);
}

int main() {
    char* message = "Function is ending";
    nob_defer(print_message, message);

    printf("Function is running...\n");
    return 0;
}
```

## Implementation Details
- `NOB_DEFER_DATA` struct for storing cleanup function and argument
- Generic `defer_cleanup()` function for executing cleanup operations
- Convenience functions for common operations (`nob_defer_free`, `nob_defer_fclose`)
- Helper macros for creating unique variable names

## Future Possibilities
- Add more convenience functions for common cleanup patterns
- Potential integration with nob's existing error handling

Would love to hear your thoughts on this implementation and any suggestions for improvement!