### PR TITLE
Switch prefix stripping to opt-in

### DIFF
--- a/nob.c
+++ b/nob.c
@@ -1,6 +1,6 @@
 #include "shared.h"
 #define NOB_IMPLEMENTATION
-#define NOB_STRIP_PREFIX
+#define NOB_ADD_PREFIX
 #define NOB_EXPERIMENTAL_DELETE_OLD
 #include "nob.h"
 
@@ -20,30 +20,30 @@ const char *test_names[] = {
     "sb_appendf",
     "da_foreach",
 };
-#define test_names_count ARRAY_LEN(test_names)
+#define test_names_count NOB_ARRAY_LEN(test_names)
 
-bool build_and_run_test(Cmd *cmd, const char *test_name)
+bool build_and_run_test(Nob_Cmd *cmd, const char *test_name)
 {
-    size_t mark = temp_save();
+    size_t mark = nob_temp_save();
 
-    const char *bin_path = temp_sprintf("%s%s", BUILD_FOLDER TESTS_FOLDER, test_name);
-    const char *src_path = temp_sprintf("%s%s.c", TESTS_FOLDER, test_name);
+    const char *bin_path = nob_temp_sprintf("%s%s", BUILD_FOLDER TESTS_FOLDER, test_name);
+    const char *src_path = nob_temp_sprintf("%s%s.c", TESTS_FOLDER, test_name);
     nob_cc(cmd);
     nob_cc_flags(cmd);
     nob_cc_output(cmd, bin_path);
     nob_cc_inputs(cmd, src_path);
-    if (!cmd_run_sync_and_reset(cmd)) return false;
+    if (!nob_cmd_run_sync_and_reset(cmd)) return false;
 
-    const char *test_cwd_path = temp_sprintf("%s%s%s.cwd", BUILD_FOLDER, TESTS_FOLDER, test_name);
-    if (!mkdir_if_not_exists(test_cwd_path)) return false;
-    if (!set_current_dir(test_cwd_path)) return false;
-    cmd_append(cmd, temp_sprintf("../%s", test_name));
-    if (!cmd_run_sync_and_reset(cmd))    return false;
-    if (!set_current_dir("../../../")) return false;
+    const char *test_cwd_path = nob_temp_sprintf("%s%s%s.cwd", BUILD_FOLDER, TESTS_FOLDER, test_name);
+    if (!nob_mkdir_if_not_exists(test_cwd_path)) return false;
+    if (!nob_set_current_dir(test_cwd_path)) return false;
+    nob_cmd_append(cmd, nob_temp_sprintf("../%s", test_name));
+    if (!nob_cmd_run_sync_and_reset(cmd))    return false;
+    if (!nob_set_current_dir("../../../")) return false;
 
-    nob_log(INFO, "--- %s finished ---", bin_path);
+    nob_log(NOB_INFO, "--- %s finished ---", bin_path);
 
-    temp_rewind(mark);
+    nob_temp_rewind(mark);
     return true;
 }
 
@@ -51,14 +51,14 @@ int main(int argc, char **argv)
 {
     NOB_GO_REBUILD_URSELF_PLUS(argc, argv, "nob.h", "shared.h");
 
-    Cmd cmd = {0};
+    Nob_Cmd cmd = {0};
 
-    const char *program_name = shift(argv, argc);
+    const char *program_name = nob_shift(argv, argc);
     const char *command_name = "test";
-    if (argc > 0) command_name = shift(argv, argc);
+    if (argc > 0) command_name = nob_shift(argv, argc);
 
-    if (!mkdir_if_not_exists(BUILD_FOLDER)) return 1;
-    if (!mkdir_if_not_exists(BUILD_FOLDER TESTS_FOLDER)) return 1;
+    if (!nob_mkdir_if_not_exists(BUILD_FOLDER)) return 1;
+    if (!nob_mkdir_if_not_exists(BUILD_FOLDER TESTS_FOLDER)) return 1;
 
     if (strcmp(command_name, "test") == 0) {
         if (argc <= 0) {
@@ -69,21 +69,22 @@ int main(int argc, char **argv)
         }
 
         while (argc > 0) {
-            const char *test_name = shift(argv, argc);
+            const char *test_name = nob_shift(argv, argc);
             if (!build_and_run_test(&cmd, test_name)) return 1;
         }
         return 0;
     }
 
     if (strcmp(command_name, "list") == 0) {
-        nob_log(INFO, "Tests:");
+        nob_log(NOB_INFO, "Tests:");
         for (size_t i = 0; i < test_names_count; ++i) {
-            nob_log(INFO, "    %s", test_names[i]);
+            nob_log(NOB_INFO, "    %s", test_names[i]);
         }
-        nob_log(INFO, "Use %s test <names...> to run individual tests", program_name);
+        nob_log(NOB_INFO, "Use %s test <names...> to run individual tests", program_name);
         return 0;
     }
 
-    nob_log(ERROR, "Unknown command %s", command_name);
+    nob_log(NOB_ERROR, "Unknown command %s", command_name);
     return 1;
 }
+

--- a/shared.h
+++ b/shared.h
@@ -9,13 +9,14 @@
 #define TESTS_FOLDER "tests/"
 
 #if defined(_MSC_VER)
-#  define nob_cc_flags(cmd) cmd_append(cmd, "-I.")
+#  define nob_cc_flags(cmd) nob_cmd_append(cmd, "-I.")
 #elif defined(__APPLE__) || defined(__MACH__)
 // TODO: "-std=c99", "-D_POSIX_SOURCE" didn't work for MacOS, don't know why, don't really care that much at the moment.
 //   Anybody who does feel free to investigate.
-#  define nob_cc_flags(cmd) cmd_append(cmd, "-Wall", "-Wextra", "-Wswitch-enum", "-I.")
+#  define nob_cc_flags(cmd) nob_cmd_append(cmd, "-Wall", "-Wextra", "-Wswitch-enum", "-I.")
 #else
-#  define nob_cc_flags(cmd) cmd_append(cmd, "-Wall", "-Wextra", "-Wswitch-enum", "-std=c99", "-D_POSIX_SOURCE", "-ggdb", "-I.");
+#  define nob_cc_flags(cmd) nob_cmd_append(cmd, "-Wall", "-Wextra", "-Wswitch-enum", "-std=c99", "-D_POSIX_SOURCE", "-ggdb", "-I.");
 #endif
 
 #endif // SHARED_H_
+


### PR DESCRIPTION
Per a comment on a recent stream, switch NOB_STRIP_PREFIX to NOB_ADD_PREFIX and set it to work in reverse. That is, only add prefixes if desired, to mitigate name collisions. Update shared.h code to comport with this, as well as nob.c to show it in action, as well as changed documentation to reflect the changes. Happy to switch to only updating the main nob.h file.