### PR TITLE
Add macro nob_da_swap to swap elements in a dynamic array

### DIFF
--- a/nob.c
+++ b/nob.c
@@ -15,6 +15,7 @@ const char *test_names[] = {
     "read_entire_dir",
     "da_resize",
     "da_last",
+    "da_swap",
     "da_remove_unordered",
     "da_append",
     "sb_appendf",

--- a/nob.h
+++ b/nob.h
@@ -321,6 +321,17 @@ bool nob_delete_file(const char *path);
         (da)->items[j] = (da)->items[--(da)->count]; \
     } while(0)
 
+#define nob_da_swap(da, i, j)                           \
+    do {                                                \
+        size_t ii = (i);                                \
+        size_t jj = (j);                                \
+        NOB_ASSERT(ii < (da)->count);                   \
+        NOB_ASSERT(jj < (da)->count);                   \
+        nob_da_append((da), (da)->items[ii]);           \
+        (da)->items[ii] = (da)->items[jj];              \
+        (da)->items[jj] = (da)->items[--((da)->count)]; \
+    } while(0)
+
 // Foreach over Dynamic Arrays. Example:
 // ```c
 // typedef struct {
@@ -1927,6 +1938,7 @@ int closedir(DIR *dirp)
         #define da_reserve nob_da_reserve
         #define da_last nob_da_last
         #define da_remove_unordered nob_da_remove_unordered
+        #define da_swap nob_da_swap
         #define da_foreach nob_da_foreach
         #define String_Builder Nob_String_Builder
         #define read_entire_file nob_read_entire_file

--- a/tests/da_swap.c
+++ b/tests/da_swap.c
@@ -1,0 +1,19 @@
+#define NOB_IMPLEMENTATION
+#define NOB_STRIP_PREFIX
+#include "nob.h"
+
+typedef struct {
+    int *items;
+    size_t count;
+    size_t capacity;
+} Numbers;
+
+int main(void)
+{
+    nob_log(INFO, "da_swap:");
+    Numbers xs = {0};
+    for (int i = 1; i <= 10; ++i) da_append(&xs, i);
+    for (int i = 0; i < 5; ++i) da_swap(&xs, i, xs.count - i - 1);
+    for (int i = 0; i < 10; ++i) nob_log(INFO, "%d", xs.items[i]);
+    return 0;
+}


### PR DESCRIPTION
I implemented a da_swap macro to swap two elements by index in a da. I think swapping is something that might be useful in more than one case (especially when using nob.h also as library and not only as build tool) and as such it would be a nice feature to come with nob.

Instead of using a temp variable I chose to use the da itself as temporary storage. The main advantage of this comes in a nice UX where the caller does not have to supply the type of the elements in the array. 

There is obviously a bit of an overhead when calling da_append but in my opinion it's totally negligible. 