### PR TITLE
add new function to render the command line on windows

### DIFF
--- a/nob.c
+++ b/nob.c
@@ -9,6 +9,7 @@ const char *test_names[] = {
     "nob_sv_end_with",
     "set_get_current_dir",
     "cmd_redirect",
+    "cmd_args_passing",
 #ifdef _WIN32
     "win32_error",
 #endif //_WIN32

--- a/tests/cmd_args_passing.c
+++ b/tests/cmd_args_passing.c
@@ -1,0 +1,35 @@
+#define NOB_IMPLEMENTATION
+#define NOB_STRIP_PREFIX
+#include "nob.h"
+
+int main(void)
+{
+    Cmd cmd = {0};
+
+    const char *print_args_src =
+        "#include <stdio.h>\n"
+        "\n"
+        "int main(int argc, char **argv) {\n"
+        "    for (int i = 1; i < argc; ++i) {\n"
+        "        printf(\"%d: %s\\n\", i, argv[i]);\n"
+        "    }\n"
+        "    return 0;\n"
+        "}\n";
+    if (!write_entire_file("print_args.c", print_args_src, strlen(print_args_src))) return 1;
+
+    nob_cc(&cmd);
+    nob_cc_flags(&cmd);
+    nob_cc_output(&cmd, "print_args");
+    nob_cc_inputs(&cmd, "print_args.c");
+    if (!cmd_run_sync_and_reset(&cmd)) return 1;
+
+    cmd_append(&cmd, "./print_args");
+    cmd_append(&cmd, "foo");
+    cmd_append(&cmd, "bar");
+    cmd_append(&cmd, "Hello, world");
+    cmd_append(&cmd, "\"Hello, world\"");
+    cmd_append(&cmd, "\"\\` %$*@");
+    if (!cmd_run_sync_and_reset(&cmd)) return 1;
+
+    return 0;
+}

--- a/tests/cmd_redirect.c
+++ b/tests/cmd_redirect.c
@@ -33,11 +33,7 @@ int main(void)
     nob_cc_inputs(&cmd, "./echo.c");
     if (!cmd_run_sync_and_reset(&cmd)) return_defer(1);
 
-    // TODO: fix the rendering of the shell command on Windows.
-    //   It prevents use from using the message with spaces here.
-    //   Steal some code from C3 compiler, I already implemented it there.
-    // const char *message = "Hello, World";
-    const char *message = "Hello";
+    const char *message = "Hello, World";
     const char *message_file_path = "./echo_message.txt";
 
     fdout = fd_open_for_write(message_file_path);


### PR DESCRIPTION
This function is based on [this article](https://learn.microsoft.com/en-gb/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way), also see [this](https://github.com/rust-lang/rust/blob/1.86.0/library/std/src/sys/pal/windows/args.rs#L205)

Because the command line situation on Windows is a mess, this solution is not secure e.g. when someone runs `cmd.exe`, but I think it's good enough...