### PR TITLE
Add check for `__clang__` in lone `_MSC_VER` checks

### DIFF
--- a/nob.h
+++ b/nob.h
@@ -507,7 +507,7 @@ bool nob_set_current_dir(const char *path);
 #endif // nob_cc
 
 #ifndef nob_cc_flags
-#  if defined(_MSC_VER)
+#  if defined(_MSC_VER) && !defined(__clang__)
 #    define nob_cc_flags(...)  // TODO: Add some cool recommended flags for MSVC (I don't really know any)
 #  else
 #    define nob_cc_flags(cmd) nob_cmd_append(cmd, "-Wall", "-Wextra")
@@ -515,7 +515,7 @@ bool nob_set_current_dir(const char *path);
 #endif // nob_cc_output
 
 #ifndef nob_cc_output
-#  if defined(_MSC_VER)
+#  if defined(_MSC_VER) && !defined(__clang__)
 #    define nob_cc_output(cmd, output_path) nob_cmd_append(cmd, nob_temp_sprintf("/Fe:%s", (output_path)))
 #  else
 #    define nob_cc_output(cmd, output_path) nob_cmd_append(cmd, "-o", (output_path))


### PR DESCRIPTION
The `nob_cc_flags` and `nob_cc_output` macros check for `_MSC_VER` to provide MSVC-specific argument syntax. When using Clang on Windows it provides many of the same flags as MSVC, presumably for Windows compat, so Nob was generating MSVC flags for a Clang compiler call.

This is not an issue in other locations as `__clang__` is checked for explicitly and before `_MSC_VER`, such as in the related `nob_cc` macro for selecting the appropriate compiler program name.