### PR TITLE
Added cool recommended flags to MSVC nob_cc_flags()

### DIFF
--- a/nob.h
+++ b/nob.h
@@ -513,7 +513,7 @@ bool nob_set_current_dir(const char *path);
 
 #ifndef nob_cc_flags
 #  if defined(_MSC_VER) && !defined(__clang__)
-#    define nob_cc_flags(...)  // TODO: Add some cool recommended flags for MSVC (I don't really know any)
+#    define nob_cc_flags(cmd) nob_cmd_append(cmd, "/W4")
 #  else
 #    define nob_cc_flags(cmd) nob_cmd_append(cmd, "-Wall", "-Wextra")
 #  endif

--- a/nob.h
+++ b/nob.h
@@ -513,7 +513,7 @@ bool nob_set_current_dir(const char *path);
 
 #ifndef nob_cc_flags
 #  if defined(_MSC_VER) && !defined(__clang__)
-#    define nob_cc_flags(cmd) nob_cmd_append(cmd, "/W4")
+#    define nob_cc_flags(cmd) nob_cmd_append(cmd, "/W4", "/nologo", "/D_CRT_SECURE_NO_WARNINGS")
 #  else
 #    define nob_cc_flags(cmd) nob_cmd_append(cmd, "-Wall", "-Wextra")
 #  endif

--- a/shared.h
+++ b/shared.h
@@ -9,7 +9,7 @@
 #define TESTS_FOLDER "tests/"
 
 #if defined(_MSC_VER)
-#  define nob_cc_flags(cmd) cmd_append(cmd, "-I.")
+#  define nob_cc_flags(cmd) cmd_append(cmd, "/W4", "-I.")
 #elif defined(__APPLE__) || defined(__MACH__)
 // TODO: "-std=c99", "-D_POSIX_SOURCE" didn't work for MacOS, don't know why, don't really care that much at the moment.
 //   Anybody who does feel free to investigate.

--- a/shared.h
+++ b/shared.h
@@ -9,7 +9,7 @@
 #define TESTS_FOLDER "tests/"
 
 #if defined(_MSC_VER)
-#  define nob_cc_flags(cmd) cmd_append(cmd, "/W4", "-I.")
+#  define nob_cc_flags(cmd) cmd_append(cmd, "/W4", "/nologo", "/D_CRT_SECURE_NO_WARNINGS", "-I.")
 #elif defined(__APPLE__) || defined(__MACH__)
 // TODO: "-std=c99", "-D_POSIX_SOURCE" didn't work for MacOS, don't know why, don't really care that much at the moment.
 //   Anybody who does feel free to investigate.


### PR DESCRIPTION
functionally equivalent to `-Wall -Wextra` on gcc/clang (adds most but not all warnings)