### PR TITLE
Minor Typo

### DIFF
--- a/nob.h
+++ b/nob.h
@@ -560,10 +560,9 @@ bool nob_set_current_dir(const char *path);
 //         return 0;
 //     }
 //
-//   After your added this macro every time you run ./nob it will detect
-//   that you modified its original source code and will try to rebuild itself
-//   before doing any actual work. So you only need to bootstrap your build system
-//   once.
+//   After you add this macro ./nob it will detect modifications to its
+//   original source code and will try to rebuild itself before doing any actual 
+//   work. So you only need to bootstrap the build system once.
 //
 //   The modification is detected by comparing the last modified times of the executable
 //   and its source code. The same way the make utility usually does it.


### PR DESCRIPTION
https://github.com/tsoding/nob.h/blob/45fa6efcd3e105bb4e39fa4cb9b57c19690d00a2/nob.h#L563

Typo: "After [your] added this macro" -> "After [you] added this macro"

Recommended: 

```
//   After you add this macro ./nob it will detect modifications to its
//   original source code and will try to rebuild itself before doing any actual 
//   work. So you only need to bootstrap the build system once.
```