### PR TITLE
Colored log statements

### DIFF
--- a/nob.h
+++ b/nob.h
@@ -244,6 +244,21 @@ extern Nob_Log_Level nob_minimal_log_level;
 
 void nob_log(Nob_Log_Level level, const char *fmt, ...) NOB_PRINTF_FORMAT(2, 3);
 
+
+typedef enum {
+	NOB_RED,
+	NOB_YELLOW,
+	NOB_GREEN,
+	NOB_GRAY,
+	NOB_RESET, // I.e. reset to default.
+} Nob_Color;
+
+// Returns true if color should be disabled.
+bool nob_no_color(void);
+
+// Return ansi escape sequence for the given color.
+char *nob_get_ansi_color(Nob_Color color);
+
 // It is an equivalent of shift command from bash. It basically pops an element from
 // the beginning of a sized array.
 #define nob_shift(xs, xs_sz) (NOB_ASSERT((xs_sz) > 0), (xs_sz)--, *(xs)++)
@@ -693,6 +708,25 @@ char *nob_win32_error_message(DWORD err);
 
 // Any messages with the level below nob_minimal_log_level are going to be suppressed.
 Nob_Log_Level nob_minimal_log_level = NOB_INFO;
+
+bool nob_no_color(void) {
+    char *no_color = getenv("NO_COLOR");
+    return no_color != NULL && no_color[0] != '\0';
+}
+
+char *nob_get_ansi_color(Nob_Color color) {
+    if (nob_no_color())
+        return "";
+
+    switch (color) {
+    case NOB_RED:    return "\x1b[91m";
+    case NOB_YELLOW: return "\x1b[93m";
+    case NOB_GREEN:  return "\x1b[92m";
+    case NOB_GRAY:   return "\x1b[31m";
+    case NOB_RESET:  return "\x1b[0m";
+    default:         NOB_UNREACHABLE("nob_get_ansi_color");
+    }
+}
 
 #ifdef _WIN32
 
@@ -1947,6 +1981,13 @@ int closedir(DIR *dirp)
         #define NO_LOGS NOB_NO_LOGS
         #define Log_Level Nob_Log_Level
         #define minimal_log_level nob_minimal_log_level
+        #define RED NOB_RED
+        #define YELLOW NOB_YELLOW
+        #define GREEN NOB_GREEN
+        #define GRAY NOB_GRAY
+        #define RESET NOB_RESET
+        #define no_color nob_no_color
+        #define get_ansi_color nob_get_ansi_color
         // NOTE: Name log is already defined in math.h and historically always was the natural logarithmic function.
         // So there should be no reason to strip the `nob_` prefix in this specific case.
         // #define log nob_log

--- a/nob.h
+++ b/nob.h
@@ -1288,13 +1288,13 @@ void nob_log(Nob_Log_Level level, const char *fmt, ...)
 
     switch (level) {
     case NOB_INFO:
-        fprintf(stderr, "[INFO] ");
+        fprintf(stderr, "[%sINFO%s] ", nob_get_ansi_color(NOB_GREEN), nob_get_ansi_color(NOB_RESET));
         break;
     case NOB_WARNING:
-        fprintf(stderr, "[WARNING] ");
+        fprintf(stderr, "[%sWARNING%s] ", nob_get_ansi_color(NOB_YELLOW), nob_get_ansi_color(NOB_RESET));
         break;
     case NOB_ERROR:
-        fprintf(stderr, "[ERROR] ");
+        fprintf(stderr, "[%sERROR%s] ", nob_get_ansi_color(NOB_RED), nob_get_ansi_color(NOB_RESET));
         break;
     case NOB_NO_LOGS: return;
     default:


### PR DESCRIPTION
Color makes it easier to find problematic log entries at a glance. This PR adds ANSI escape sequences that color log entries according to their log levels.

Respects the [`NO_COLOR` environment variable](https://no-color.org/).

Naming could probably be improved.