### PR TITLE
Disable _CRT_SECURE_DEPRECATE warnings on Windows.

### DIFF
--- a/nob.h
+++ b/nob.h
@@ -164,6 +164,9 @@
 
 #ifndef NOB_H_
 #define NOB_H_
+#ifdef _WIN32
+#define _CRT_SECURE_NO_WARNINGS (1)
+#endif
 
 #ifndef NOB_ASSERT
 #include <assert.h>

--- a/nob.h
+++ b/nob.h
@@ -796,7 +796,7 @@ static char nob_temp[NOB_TEMP_CAPACITY] = {0};
 bool nob_mkdir_if_not_exists(const char *path)
 {
 #ifdef _WIN32
-    int result = mkdir(path);
+    int result = _mkdir(path);
 #else
     int result = mkdir(path, 0755);
 #endif


### PR DESCRIPTION
When using nob.h as is on window you get a bunch of stupid warnings, because Microsoft marked most standard C library functions as deprecated to encourage non-portable Annex K *_s functions.
```
.\nob.h:796:18: warning: 'mkdir' is deprecated: The POSIX name for this item is deprecated. Instead, use the ISO C and
      C++ conformant name: _mkdir. See online help for details. [-Wdeprecated-declarations]
  796 |     int result = mkdir(path);
      |                  ^
C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\ucrt\direct.h:114:20: note: 'mkdir' has been explicitly
      marked deprecated here
  114 |     _Check_return_ _CRT_NONSTDC_DEPRECATE(_mkdir)
      |                    ^
C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\ucrt\corecrt.h:428:50: note: expanded from macro
      '_CRT_NONSTDC_DEPRECATE'
  428 |         #define _CRT_NONSTDC_DEPRECATE(_NewName) _CRT_DEPRECATE_TEXT(             \
      |                                                  ^
C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.43.34808\include\vcruntime.h:358:47: note:
      expanded from macro '_CRT_DEPRECATE_TEXT'
  358 | #define _CRT_DEPRECATE_TEXT(_Text) __declspec(deprecated(_Text))
      |                                               ^
In file included from main.c:2:
.\nob.h:805:73: warning: 'strerror' is deprecated: This function or variable may be unsafe. Consider using strerror_s
      instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
      [-Wdeprecated-declarations]
  805 |         nob_log(NOB_ERROR, "could not create directory `%s`: %s", path, strerror(errno));
      |                                                                         ^
C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\ucrt\string.h:177:16: note: 'strerror' has been explicitly
      marked deprecated here
  177 | _Check_return_ _CRT_INSECURE_DEPRECATE(strerror_s)
      |                ^
C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.43.34808\include\vcruntime.h:368:55: note:
      expanded from macro '_CRT_INSECURE_DEPRECATE'
  368 |         #define _CRT_INSECURE_DEPRECATE(_Replacement) _CRT_DEPRECATE_TEXT(    \
      |                                                       ^
C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.43.34808\include\vcruntime.h:358:47: note:
      expanded from macro '_CRT_DEPRECATE_TEXT'
  358 | #define _CRT_DEPRECATE_TEXT(_Text) __declspec(deprecated(_Text))
      |                                               ^
In file included from main.c:2:
.\nob.h:1317:15: warning: 'fopen' is deprecated: This function or variable may be unsafe. Consider using fopen_s
      instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
      [-Wdeprecated-declarations]
 1317 |     FILE *f = fopen(path, "wb");
      |               ^
C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\ucrt\stdio.h:212:20: note: 'fopen' has been explicitly
      marked deprecated here
  212 |     _Check_return_ _CRT_INSECURE_DEPRECATE(fopen_s)
      |                    ^
C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.43.34808\include\vcruntime.h:368:55: note:
      expanded from macro '_CRT_INSECURE_DEPRECATE'
  368 |         #define _CRT_INSECURE_DEPRECATE(_Replacement) _CRT_DEPRECATE_TEXT(    \
      |                                                       ^
C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.43.34808\include\vcruntime.h:358:47: note:
      expanded from macro '_CRT_DEPRECATE_TEXT'
  358 | #define _CRT_DEPRECATE_TEXT(_Text) __declspec(deprecated(_Text))
      |                                               ^
In file included from main.c:2:
.\nob.h:1319:78: warning: 'strerror' is deprecated: This function or variable may be unsafe. Consider using strerror_s
      instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
      [-Wdeprecated-declarations]
 1319 |         nob_log(NOB_ERROR, "Could not open file %s for writing: %s\n", path, strerror(errno));
      |                                                                              ^
C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\ucrt\string.h:177:16: note: 'strerror' has been explicitly
      marked deprecated here
  177 | _Check_return_ _CRT_INSECURE_DEPRECATE(strerror_s)
      |                ^
C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.43.34808\include\vcruntime.h:368:55: note:
      expanded from macro '_CRT_INSECURE_DEPRECATE'
  368 |         #define _CRT_INSECURE_DEPRECATE(_Replacement) _CRT_DEPRECATE_TEXT(    \
      |                                                       ^
C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.43.34808\include\vcruntime.h:358:47: note:
      expanded from macro '_CRT_DEPRECATE_TEXT'
  358 | #define _CRT_DEPRECATE_TEXT(_Text) __declspec(deprecated(_Text))
      |                                               ^
In file included from main.c:2:
.\nob.h:1333:76: warning: 'strerror' is deprecated: This function or variable may be unsafe. Consider using strerror_s
      instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
      [-Wdeprecated-declarations]
 1333 |             nob_log(NOB_ERROR, "Could not write into file %s: %s\n", path, strerror(errno));
      |                                                                            ^
C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\ucrt\string.h:177:16: note: 'strerror' has been explicitly
      marked deprecated here
  177 | _Check_return_ _CRT_INSECURE_DEPRECATE(strerror_s)
      |                ^
C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.43.34808\include\vcruntime.h:368:55: note:
      expanded from macro '_CRT_INSECURE_DEPRECATE'
  368 |         #define _CRT_INSECURE_DEPRECATE(_Replacement) _CRT_DEPRECATE_TEXT(    \
      |                                                       ^
C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.43.34808\include\vcruntime.h:358:47: note:
      expanded from macro '_CRT_DEPRECATE_TEXT'
  358 | #define _CRT_DEPRECATE_TEXT(_Text) __declspec(deprecated(_Text))
      |                                               ^
In file included from main.c:2:
.\nob.h:1620:15: warning: 'fopen' is deprecated: This function or variable may be unsafe. Consider using fopen_s
      instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
      [-Wdeprecated-declarations]
 1620 |     FILE *f = fopen(path, "rb");
      |               ^
C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\ucrt\stdio.h:212:20: note: 'fopen' has been explicitly
      marked deprecated here
  212 |     _Check_return_ _CRT_INSECURE_DEPRECATE(fopen_s)
      |                    ^
C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.43.34808\include\vcruntime.h:368:55: note:
      expanded from macro '_CRT_INSECURE_DEPRECATE'
  368 |         #define _CRT_INSECURE_DEPRECATE(_Replacement) _CRT_DEPRECATE_TEXT(    \
      |                                                       ^
C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.43.34808\include\vcruntime.h:358:47: note:
      expanded from macro '_CRT_DEPRECATE_TEXT'
  358 | #define _CRT_DEPRECATE_TEXT(_Text) __declspec(deprecated(_Text))
      |                                               ^
In file included from main.c:2:
.\nob.h:1646:73: warning: 'strerror' is deprecated: This function or variable may be unsafe. Consider using strerror_s
      instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
      [-Wdeprecated-declarations]
 1646 |     if (!result) nob_log(NOB_ERROR, "Could not read file %s: %s", path, strerror(errno));
      |                                                                         ^
C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\ucrt\string.h:177:16: note: 'strerror' has been explicitly
      marked deprecated here
  177 | _Check_return_ _CRT_INSECURE_DEPRECATE(strerror_s)
      |                ^
C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.43.34808\include\vcruntime.h:368:55: note:
      expanded from macro '_CRT_INSECURE_DEPRECATE'
  368 |         #define _CRT_INSECURE_DEPRECATE(_Replacement) _CRT_DEPRECATE_TEXT(    \
      |                                                       ^
C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.43.34808\include\vcruntime.h:358:47: note:
      expanded from macro '_CRT_DEPRECATE_TEXT'
  358 | #define _CRT_DEPRECATE_TEXT(_Text) __declspec(deprecated(_Text))
      |                                               ^
In file included from main.c:2:
.\nob.h:1899:5: warning: 'strncpy' is deprecated: This function or variable may be unsafe. Consider using strncpy_s
      instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
      [-Wdeprecated-declarations]
 1899 |     strncpy(
      |     ^
C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\ucrt\string.h:334:1: note: 'strncpy' has been explicitly
      marked deprecated here
  334 | __DEFINE_CPP_OVERLOAD_STANDARD_NFUNC_0_2_EX(
      | ^
C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\ucrt\corecrt.h:1935:17: note: expanded from macro
      '__DEFINE_CPP_OVERLOAD_STANDARD_NFUNC_0_2_EX'
 1935 |                 _CRT_INSECURE_DEPRECATE(_SecureFuncName) _DeclSpec _ReturnType __cdecl _FuncName(_SalAttributeDs...
      |                 ^
C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.43.34808\include\vcruntime.h:368:55: note:
      expanded from macro '_CRT_INSECURE_DEPRECATE'
  368 |         #define _CRT_INSECURE_DEPRECATE(_Replacement) _CRT_DEPRECATE_TEXT(    \
      |                                                       ^
C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.43.34808\include\vcruntime.h:358:47: note:
      expanded from macro '_CRT_DEPRECATE_TEXT'
  358 | #define _CRT_DEPRECATE_TEXT(_Text) __declspec(deprecated(_Text))
      |                                               ^
8 warnings generated.
```

This PR disables those warnings.