### PR TITLE
Use native defer from C2Y standard

### DIFF
--- a/tests/cmd_redirect.c
+++ b/tests/cmd_redirect.c
@@ -4,12 +4,15 @@
 
 int main(void)
 {
-    int result = 0;
-
     Cmd cmd = {0};
     Fd fdout = INVALID_FD;
     String_Builder sb = {0};
 
+    defer {
+        free(cmd.items);
+        free(sb.items);
+        if (fdout != INVALID_FD) fd_close(fdout);
+    }
     const char *echo_src =
         "#include <assert.h>\n"
         "#include <stdio.h>\n"
@@ -31,33 +34,29 @@ int main(void)
     nob_cc_flags(&cmd);
     nob_cc_output(&cmd, "./echo");
     nob_cc_inputs(&cmd, "./echo.c");
-    if (!cmd_run_sync_and_reset(&cmd)) return_defer(1);
+    if (!cmd_run_sync_and_reset(&cmd)) return 1;
 
     const char *message = "Hello, World";
     const char *message_file_path = "./echo_message.txt";
 
     fdout = fd_open_for_write(message_file_path);
-    if (fdout == INVALID_FD) return_defer(1);
+    if (fdout == INVALID_FD) return 1;
 
     cmd_append(&cmd, "./echo", message);
     Proc p = cmd_run_async_redirect_and_reset(&cmd, (Cmd_Redirect) {.fdout = &fdout});
-    if (p == INVALID_PROC) return_defer(1);
-    if (!proc_wait(p)) return_defer(1);
+    if (p == INVALID_PROC) return 1;
+    if (!proc_wait(p)) return 1;
 
-    if (!read_entire_file(message_file_path, &sb)) return_defer(1);
+    if (!read_entire_file(message_file_path, &sb)) return 1;
     String_View actual_message = sb_to_sv(sb);
     if (!sv_eq(sv_trim(actual_message), sv_from_cstr(message))) {
         nob_log(ERROR, "Unexpected message");
         nob_log(ERROR, "Expected: %s", message);
         nob_log(ERROR, "Actual:   "SV_Fmt, SV_Arg(actual_message));
-        return_defer(1);
+        return 1;
     }
 
     nob_log(INFO, "OK");
 
-defer:
-    free(cmd.items);
-    free(sb.items);
-    if (fdout != INVALID_FD) fd_close(fdout);
-    return result;
+    return 0;
 }


### PR DESCRIPTION
This converts goto-based defer macros to native defer statements from [the C standard technical specification](https://thephd.dev/_vendor/future_cxx/technical%20specification/C%20-%20defer/C%20-%20defer%20Technical%20Specification.pdf); changes were mostly 1:1, with defer blocks moved from end to start.

There are already several [C compilers that support it](https://thephd.dev/_vendor/future_cxx/papers/C%20-%20Improved%20__attribute__%28%28cleanup%29%29%20Through%20defer.html#experience-slimcc), and I've been using patched `nob.h` to test my own implementation. With the [GCC patch](https://gcc.gnu.org/pipermail/gcc-patches/2025-August/691461.html) submitted upstream, I think people might be interested in playing with it.