### PR TITLE
Update nob_get_file_type() in nob.h

### DIFF
--- a/nob.h
+++ b/nob.h
@@ -1378,7 +1378,7 @@ Nob_File_Type nob_get_file_type(const char *path)
     return NOB_FILE_REGULAR;
 #else // _WIN32
     struct stat statbuf;
-    if (stat(path, &statbuf) < 0) {
+    if (lstat(path, &statbuf) < 0) {
         nob_log(NOB_ERROR, "Could not get stat of %s: %s", path, strerror(errno));
         return -1;
     }


### PR DESCRIPTION
Change usage of stat() to lstat() in nob_get_file_type().

stat() always follows symlinks and sets &statbuf entirely based on the destination, meaning that nob_get_file_type() will never return NOB_FILE_SYMLINK. Additionally, nob_get_file_type() will always error when a symlink is broken instead of returning NOB_FILE_SYMLINK.

lstat() doesn't follow symlinks, making nob_get_file_type() work the way we'd expect it to.