### PR TITLE
introduce nob_da_declare macro for simplifing dynamic array declaration

### DIFF
--- a/nob.h
+++ b/nob.h
@@ -338,6 +338,27 @@ NOBDEF bool nob_delete_file(const char *path);
         (da)->items[j] = (da)->items[--(da)->count]; \
     } while(0)
 
+// Declare generic structure for simplify declaration dynamic array. Example:
+// ```c
+//
+// nob_declare(int) xs = {0};
+// nob_da_append(&xs, 69);
+// nob_da_append(&xs, 420);
+// nob_da_append(&xs, 1337);
+//
+// nob_declare(char) chrs = {0};
+// nob_da_append(&chrs, 'a');
+// nob_da_append(&chrs, 'b');
+// nob_da_append(&chrs, 'c');
+//
+// ```
+#define nob_da_declare(type)		\
+	struct {			\
+		type *items;		\
+		size_t capacity;	\
+		size_t count;		\
+	}
+
 // Foreach over Dynamic Arrays. Example:
 // ```c
 // typedef struct {
@@ -2005,6 +2026,7 @@ NOBDEF int closedir(DIR *dirp)
         #define delete_file nob_delete_file
         #define return_defer nob_return_defer
         #define da_append nob_da_append
+        #define da_declare nob_da_declare
         #define da_free nob_da_free
         #define da_append_many nob_da_append_many
         #define da_resize nob_da_resize

--- a/tests/da_declare.c
+++ b/tests/da_declare.c
@@ -1,0 +1,12 @@
+#define NOB_IMPLEMENTATION
+#define NOB_STRIP_PREFIX
+#define NOB_DA_INIT_CAP 4
+#include "nob.h"
+
+int main(void){
+	da_declare(int) xs;
+	da_append(&xs , 10);
+
+	nob_log(INFO , "Hello World %d " , xs.items[0]);
+	return 0;
+}


### PR DESCRIPTION
I noticed that you have to define a new structure even if you use it only once. nob_da_declare allows you to define a generic structure type in a single line instead of explicitly declaring a structure. 