### PR TITLE
Add macro `nob_swap`

### DIFF
--- a/nob.c
+++ b/nob.c
@@ -19,6 +19,7 @@ const char *test_names[] = {
     "da_append",
     "sb_appendf",
     "da_foreach",
+    "swap",
 };
 #define test_names_count ARRAY_LEN(test_names)
 

--- a/nob.h
+++ b/nob.h
@@ -476,6 +476,19 @@ void nob_temp_reset(void);
 size_t nob_temp_save(void);
 void nob_temp_rewind(size_t checkpoint);
 
+#define nob_swap(a, b)                       \
+    do {                                     \
+        size_t sza = sizeof(a);              \
+        size_t szb = sizeof(b);              \
+        NOB_ASSERT(sza == szb);              \
+        size_t checkpoint = nob_temp_save(); \
+        void *tmp = nob_temp_alloc(sza);     \
+        memcpy(tmp, &a, sza);                \
+        memcpy(&a, &b, sza);                 \
+        memcpy(&b, tmp, sza);                \
+        nob_temp_rewind(checkpoint);         \
+    } while(0)
+
 // Given any path returns the last part of that path.
 // "/path/to/a/file.c" -> "file.c"; "/path/to/a/directory" -> "directory"
 const char *nob_path_name(const char *path);
@@ -1935,6 +1948,7 @@ int closedir(DIR *dirp)
         #define sb_append_cstr nob_sb_append_cstr
         #define sb_append_null nob_sb_append_null
         #define sb_free nob_sb_free
+        #define swap nob_swap
         #define Proc Nob_Proc
         #define INVALID_PROC NOB_INVALID_PROC
         #define Fd Nob_Fd

--- a/nob.h
+++ b/nob.h
@@ -517,8 +517,7 @@ NOBDEF void nob_temp_rewind(size_t checkpoint);
 #define nob_swap(a, b)                       \
     do {                                     \
         size_t sza = sizeof(a);              \
-        size_t szb = sizeof(b);              \
-        NOB_ASSERT(sza == szb);              \
+        NOB_ASSERT(sza == sizeof(b));        \
         size_t checkpoint = nob_temp_save(); \
         void *tmp = nob_temp_alloc(sza);     \
         memcpy(tmp, &a, sza);                \

--- a/tests/swap.c
+++ b/tests/swap.c
@@ -1,0 +1,15 @@
+#define NOB_IMPLEMENTATION
+#define NOB_STRIP_PREFIX
+#include "../nob.h"
+
+int main(void) 
+{
+    nob_log(INFO, "swap:");
+    int a = 10;
+    int b = 20;
+    nob_log(INFO, "a = %d, b = %d", a, b);
+    swap(a, b);
+    nob_log(INFO, "a = %d, b = %d", a, b);
+
+    return 0;
+}

--- a/tests/swap.c
+++ b/tests/swap.c
@@ -1,6 +1,6 @@
 #define NOB_IMPLEMENTATION
 #define NOB_STRIP_PREFIX
-#include "../nob.h"
+#include "nob.h"
 
 int main(void) 
 {


### PR DESCRIPTION
Added macro `nob_swap`, which is able to swap two variables using `nob_temp_alloc` and `memcpy` as first discussed in #61.