### PR TITLE
Add posix for mac

### DIFF
--- a/shared.h
+++ b/shared.h
@@ -11,9 +11,7 @@
 #if defined(_MSC_VER)
 #  define nob_cc_flags(cmd) cmd_append(cmd, "/W4", "/nologo", "/D_CRT_SECURE_NO_WARNINGS", "-I.")
 #elif defined(__APPLE__) || defined(__MACH__)
-// TODO: "-std=c99", "-D_POSIX_C_SOURCE=200112L" didn't work for MacOS, don't know why, don't really care that much at the moment.
-//   Anybody who does feel free to investigate.
-#  define nob_cc_flags(cmd) cmd_append(cmd, "-Wall", "-Wextra", "-Wswitch-enum", "-I.")
+#  define nob_cc_flags(cmd) cmd_append(cmd, "-Wall", "-Wextra", "-Wswitch-enum", "-std=c99", "-D_POSIX_C_SOURCE=200809L", "-I.")
 #else
 #  define nob_cc_flags(cmd) cmd_append(cmd, "-Wall", "-Wextra", "-Wswitch-enum", "-std=c99", "-D_POSIX_C_SOURCE=200112L", "-ggdb", "-I.");
 #endif


### PR DESCRIPTION
There seemed to be two options: use -D_DARWIN_C_SOURCE or newer posix source like -D_POSIX_C_SOURCE=200809L  in this commit to fix apple std=99