### PR TITLE
cmdf function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ nob
 nob.old
 nob.exe
 build/
+.clangd

--- a/tests/cmdf.c
+++ b/tests/cmdf.c
@@ -1,0 +1,9 @@
+#define NOB_IMPLEMENTATION
+#include "../nob.h"
+
+int main(int argc, char** argv) {
+	NOB_GO_REBUILD_URSELF(argc, argv);
+
+	Nob_Cmd cmd = nob_cmdf(NULL, "cc -o cmdf cmdf.c");
+	if(!nob_cmd_run_async_and_reset(&cmd)) return 1;
+}


### PR DESCRIPTION
# nob.h cmdf

This PR adds a `cmdf` function that creates a new command from a format string allowing commands to be created faster.

## Examples

**Simple Compiler**

```c
#defined NOB_IMPLEMENTATION
#include "nob.h"

int main() {
    // create a new command from a format string
    Nob_Cmd cmd = nob_cmdf(NULL, "cc -o main");
    // append sections from format string to existing command
    nob_cmdf(&cmd, "main.c");

    // run cmd
    // ...
}
```

**List of Files**

```c
#defined NOB_IMPLEMENTATION
#include "nob.h"

int main() {
    for(int i = 0; i < 10; i++) {
        Nob_Cmd cmd = nob_cmdf(NULL, "echo number: %d > file%d.txt", i, i);
        if(!nob_cmd_run_sync_and_reset(&cmd)) return 1;
    }
}
```

## Additions

```c
// Reset a command to size 0 and free buffer memory if it exists
NOBDEF void nob_cmd_reset(Nob_Cmd* cmd);

// Builds a command using a format string and va arguments. Splits the command by spaces.
// If a command pointer is supplied, the parsed command is appended to the end of the input 
// command; this value can be left NULL to create a new command.
NOBDEF Nob_Cmd nob_cmdf(Nob_Cmd* cmd, const char* fmt, ...);

typedef struct {
    const char **items;
    size_t count;
    size_t capacity;
    // added item_buffers field (dynamic array)
	struct {
		char** items;
		size_t count;
		size_t capacity;
	} item_buffers;
} Nob_Cmd;

// other defs for nob_cc that are just string variants
// eg.
nob_cmdf(NULL, "%s %s %s main.c", nob_cc_str(), nob_cc_flags_str(), nob_cc_output_str("main"));
```

I also replaced instances of setting a command size to 0 `nob_cmd_reset` which will also free any buffers that were needed to split strings. I used `NOB_REALLOC` with `NULL` for allocating, I wasn't quite sure what should have been used.