### PR TITLE
introduce nob_main define

### DIFF
--- a/nob.c
+++ b/nob.c
@@ -51,32 +51,30 @@ bool build_and_run_test(Cmd *cmd, const char *test_name)
     return true;
 }
 
-int main(int argc, char **argv)
+nob_main(int argc, char **argv, Cmd *cmd)
 {
     NOB_GO_REBUILD_URSELF_PLUS(argc, argv, "nob.h", "shared.h");
-
-    Cmd cmd = {0};
 
     const char *program_name = shift(argv, argc);
     const char *command_name = "test";
     if (argc > 0) command_name = shift(argv, argc);
 
-    if (!mkdir_if_not_exists(BUILD_FOLDER)) return 1;
-    if (!mkdir_if_not_exists(BUILD_FOLDER TESTS_FOLDER)) return 1;
+    if (!mkdir_if_not_exists(BUILD_FOLDER)) return false;
+    if (!mkdir_if_not_exists(BUILD_FOLDER TESTS_FOLDER)) return false;
 
     if (strcmp(command_name, "test") == 0) {
         if (argc <= 0) {
             for (size_t i = 0; i < test_names_count; ++i) {
-                if (!build_and_run_test(&cmd, test_names[i])) return 1;
+                if (!build_and_run_test(cmd, test_names[i])) return false;
             }
-            return 0;
+            return true;
         }
 
         while (argc > 0) {
             const char *test_name = shift(argv, argc);
-            if (!build_and_run_test(&cmd, test_name)) return 1;
+            if (!build_and_run_test(cmd, test_name)) return false;
         }
-        return 0;
+        return true;
     }
 
     if (strcmp(command_name, "list") == 0) {
@@ -85,9 +83,9 @@ int main(int argc, char **argv)
             nob_log(INFO, "    %s", test_names[i]);
         }
         nob_log(INFO, "Use %s test <names...> to run individual tests", program_name);
-        return 0;
+        return true;
     }
 
     nob_log(ERROR, "Unknown command %s", command_name);
-    return 1;
+    return false;
 }

--- a/nob.h
+++ b/nob.h
@@ -1881,6 +1881,7 @@ NOBDEF bool nob_set_current_dir(const char *path)
 #define NOB_MAIN_ARGS_3 argc, argv, &cmd
 #define NOB_MAIN_ARGS_4 argc, argv, &cmd, &procs
 #define SELECT_NOB_MAIN_ARGS(_1, _2, _3, _4, NAME, ...) NAME
+#define NOB_VA_EXPAND(x) x
 
 #define nob_main(...)                                                       \
     NOBDEF bool nob_main_implementation(__VA_ARGS__);                       \
@@ -1892,14 +1893,14 @@ NOBDEF bool nob_set_current_dir(const char *path)
         NOB_UNUSED(cmd);                                                    \
         Nob_Procs procs = {0};                                              \
         NOB_UNUSED(procs);                                                  \
-        if (!nob_main_implementation(                                       \
+        if (!nob_main_implementation(NOB_VA_EXPAND(                         \
             SELECT_NOB_MAIN_ARGS(__VA_ARGS__,                               \
                 NOB_MAIN_ARGS_4,                                            \
                 NOB_MAIN_ARGS_3,                                            \
                 NOB_MAIN_ARGS_2,                                            \
                 NOB_MAIN_ARGS_1,                                            \
             )                                                               \
-        )) return 1;                                                        \
+        ))) return 1;                                                       \
         return 0;                                                           \
     }                                                                       \
     NOBDEF bool nob_main_implementation(__VA_ARGS__)

--- a/nob.h
+++ b/nob.h
@@ -1876,6 +1876,34 @@ NOBDEF bool nob_set_current_dir(const char *path)
 #endif // _WIN32
 }
 
+#define NOB_MAIN_ARGS_1
+#define NOB_MAIN_ARGS_2 argc, argv
+#define NOB_MAIN_ARGS_3 argc, argv, &cmd
+#define NOB_MAIN_ARGS_4 argc, argv, &cmd, &procs
+#define SELECT_NOB_MAIN_ARGS(_1, _2, _3, _4, NAME, ...) NAME
+
+#define nob_main(...)                                                       \
+    NOBDEF bool nob_main_implementation(__VA_ARGS__);                       \
+    int main(int argc, char **argv)                                         \
+    {                                                                       \
+        NOB_UNUSED(argc);                                                   \
+        NOB_UNUSED(argv);                                                   \
+        Nob_Cmd cmd = {0};                                                  \
+        NOB_UNUSED(cmd);                                                    \
+        Nob_Procs procs = {0};                                              \
+        NOB_UNUSED(procs);                                                  \
+        if (!nob_main_implementation(                                       \
+            SELECT_NOB_MAIN_ARGS(__VA_ARGS__,                               \
+                NOB_MAIN_ARGS_4,                                            \
+                NOB_MAIN_ARGS_3,                                            \
+                NOB_MAIN_ARGS_2,                                            \
+                NOB_MAIN_ARGS_1,                                            \
+            )                                                               \
+        )) return 1;                                                        \
+        return 0;                                                           \
+    }                                                                       \
+    NOBDEF bool nob_main_implementation(__VA_ARGS__)
+
 // minirent.h SOURCE BEGIN ////////////////////////////////////////
 #if defined(_WIN32) && !defined(NOB_NO_MINIRENT)
 struct DIR

--- a/tests/cmd_args_passing.c
+++ b/tests/cmd_args_passing.c
@@ -2,7 +2,7 @@
 #define NOB_STRIP_PREFIX
 #include "nob.h"
 
-int main(void)
+nob_main(void)
 {
     Cmd cmd = {0};
 
@@ -15,13 +15,13 @@ int main(void)
         "    }\n"
         "    return 0;\n"
         "}\n";
-    if (!write_entire_file("print_args.c", print_args_src, strlen(print_args_src))) return 1;
+    if (!write_entire_file("print_args.c", print_args_src, strlen(print_args_src))) return false;
 
     nob_cc(&cmd);
     nob_cc_flags(&cmd);
     nob_cc_output(&cmd, "print_args");
     nob_cc_inputs(&cmd, "print_args.c");
-    if (!cmd_run_sync_and_reset(&cmd)) return 1;
+    if (!cmd_run_sync_and_reset(&cmd)) return false;
 
     cmd_append(&cmd, "./print_args");
     cmd_append(&cmd, "foo");
@@ -29,7 +29,7 @@ int main(void)
     cmd_append(&cmd, "Hello, world");
     cmd_append(&cmd, "\"Hello, world\"");
     cmd_append(&cmd, "\"\\` %$*@");
-    if (!cmd_run_sync_and_reset(&cmd)) return 1;
+    if (!cmd_run_sync_and_reset(&cmd)) return false;
 
-    return 0;
+    return true;
 }


### PR DESCRIPTION
## What was done
- added nob_main define that unifies writing experience between main function and separate build functions, in terms of:
  + `nob_main` declared function returns bool value same as all `nob_` utilities and in most of the cases `build_<something>` functions defined by users in `nob.c`
  + `nob_main` can accept `Nob_Cmd *cmd` and `Nob_Procs *procs` as arguments, so there would not be inconsistencies n code base between calling `nob_` utils in `main` function or in the separate `build` helper function

Example:
```c
nob_main(int argc, char **argv, Cmd *cmd, Procs *procs)
{
    GO_REBUILD_URSELS(argc, argv);
    cmd_append(cmd, "echo", "test");
    if (!cmd_run_sync_and_reset(cmd)) return false;
    return true;
}
```

You can either specify `nob_main(void)` argument to not receive any in main, standard `nob_main(int argc, char **argv[, Cmd *cmd[, Procs *procs]])`. `nob_main` define will decide what arguments to pass to your `main` based on amount of arguments passed to `nod_main`.

## Reasoning
It's more like a convenience thing for eliminating need for refactor whenever you trying to move something out of main function to utility or the other way around.

At any time of development you can just change `nob_main()` to `bool build_old()` and create new main that would use `build_old` as a subcommand for example, without any refactoring.

<details>
<summary>Example of where this would have helped</summary>

![IMG_2764](https://github.com/user-attachments/assets/6e962203-97f2-407d-ab00-501618ad7fcb)

</details>

## Cons

There are some things that I personally don't like about this implementation, and why I hasn't submitted it before
- can't explicitly declare return type of `nob_main`
- can't strip prefix from `nob_main`
- adds a bunch of defines that can't be repurposed for anything else except for main function arguments guessing