### PR TITLE
Add NOB_ASSERT that doesnt depend on assert.h

### DIFF
--- a/nob.h
+++ b/nob.h
@@ -193,8 +193,8 @@
         : (void)0)
 #else
 #define NOB_ASSERT(expr) ((void)0)
-#endif /* NOB_ASSERT */
 #endif /* NDEBUG */
+#endif /* NOB_ASSERT */
 
 #ifndef NOB_REALLOC
 #include <stdlib.h>


### PR DESCRIPTION
The main issue this solves is that when the `assert()` from libc is called in a debugger, you end up several stack levels deep and have to hunt down where the crash actually occurred. 

It ends up looking like this.
<img width="965" height="260" alt="image" src="https://github.com/user-attachments/assets/83e6afd8-d026-44bc-882d-4ee744ba9962" />

This approach instead makes the compiler generate a trap instruction and crash immediately.


PS: You could also  implement cool custom formatting for asserts, but I didn't put that in for the sake of keeping it simple.
```c
#define assertf(expr, ...)    \
    (!(expr))?     \
        (printf("%s:%d: assertion `%s` failed: \"", __FILE__, __LINE__, #expr),    \
        printf(__VA_ARGS__),  \
        printf('\"\n'),  \ 
        CRASH())    \ 
    : (void)0

assertf(a == b, "expected %d but got %d", a, b);
```

