### PR TITLE
Improve nob__proc_wait_async API

### DIFF
--- a/nob.h
+++ b/nob.h
@@ -416,7 +416,7 @@ NOBDEF int nob_nprocs(void);
 NOBDEF uint64_t nob_nanos_since_unspecified_epoch(void);
 
 // Passing 0 yields the current time slice in the OS scheduler.
-// Windows resolution is in ms, not ns, but is rounded up. 
+// Windows resolution is in ms, not ns, but is rounded up.
 NOBDEF void nob_sleep_nanos(uint64_t);
 
 // Same as nob_cmd_run_opt but using cool variadic macro to set the default options.
@@ -1106,18 +1106,18 @@ NOBDEF uint64_t nob_nanos_since_unspecified_epoch(void)
 
 NOBDEF void nob_sleep_nanos(uint64_t ns) {
 #ifdef _WIN32
-	// Not tested on windows, but it should work if it compiles
-	// round up by one if not an exact number of ms
-	size_t ms = ns / (1000*1000) + (ns % (1000*1000) > 0);
-	Sleep(ms);
-	return;
+    // Not tested on windows, but it should work if it compiles
+    // round up by one if not an exact number of ms
+    size_t ms = ns / (1000*1000) + (ns % (1000*1000) > 0);
+    Sleep(ms);
+    return;
 #else
-	struct timespec ts = {};
-	ts.tv_sec  = ns / NOB_NANOS_PER_SEC;
-	ts.tv_nsec = ns % NOB_NANOS_PER_SEC;
-	
-	nanosleep(&ts, NULL);
-	return;
+    struct timespec ts = {};
+    ts.tv_sec  = ns / NOB_NANOS_PER_SEC;
+    ts.tv_nsec = ns % NOB_NANOS_PER_SEC;
+
+    nanosleep(&ts, NULL);
+    return;
 #endif
 }
 


### PR DESCRIPTION
The API of `nob__proc_wait_async` is improved by moving out sleeps into a different function. This supports checking all of the handles in a `Nob_Procs` structure without any delay.

The previous implementation will take 14 milliseconds to check to the 15th procedure in the `Nob_Procs` struct because each check would spend a millisecond either sleeping or timing out. By decoupling checking if a process is finished from sleeping, the API is improved and control is gained.

This also creates the function `nob_sleep_nanos`.