### PR TITLE
Introduce `nob_touch_file()`

### DIFF
--- a/nob.h
+++ b/nob.h
@@ -164,6 +164,7 @@
 #    include <sys/wait.h>
 #    include <sys/stat.h>
 #    include <unistd.h>
+#    include <utime.h>
 #    include <fcntl.h>
 #endif
 
@@ -1672,7 +1673,7 @@ NOBDEF bool nob_touch_file(const char *path)
             nob_log(NOB_ERROR, "Could not touch file %s: %s", path, strerror(errno));
             return false;
         } else {
-            int fd = creat(path);
+            int fd = creat(path, 0644);
             if (fd == -1) {
                 nob_log(NOB_ERROR, "Could not touch file %s: %s", path, strerror(errno));
                 return false;


### PR DESCRIPTION
I found this useful while trying to debug #111 with a program like:

``` c
#define NOB_IMPLEMENTATION
#define NOB_EXPERIMENTAL_DELETE_OLD
#include "../nob.h"

int main(int arg, char **argv) {
    NOB_GO_REBUILD_URSELF(arg, argv);
    nob_log(NOB_INFO, "Hello, World!");
    nob_touch_file(__FILE__);
    return 0;
}
```

Maybe it's useful in general?