### PR TITLE
Add flag to enable custom implementation of nob_log

### DIFF
--- a/nob.c
+++ b/nob.c
@@ -24,6 +24,7 @@ const char *test_names[] = {
     "sb_appendf",
     "da_foreach",
     "temp_aligned_alloc",
+    "nob_log_custom_implementation",
 };
 #define test_names_count ARRAY_LEN(test_names)
 

--- a/nob.h
+++ b/nob.h
@@ -80,6 +80,8 @@
       - NOB_EXPERIMENTAL_DELETE_OLD - Experimental feature that automatically removes `nob.old` files. It's unclear how well
         it works on Windows, so it's experimental for now.
       - NOB_STRIP_PREFIX - string the `nob_` prefixes from non-redefinable names.
+      - NOB_LOG_CUSTOM_IMPLEMENTATION - Declares nob_log_default as a separate function with the same signature as nob_log
+        and renames the definition of nob_log to nob_log_default. The user must define and implement nob_log themselves.
 
    ## Redefinable Macros
 
@@ -203,7 +205,12 @@ typedef enum {
 // Any messages with the level below nob_minimal_log_level are going to be suppressed.
 extern Nob_Log_Level nob_minimal_log_level;
 
-NOBDEF void nob_log(Nob_Log_Level level, const char *fmt, ...) NOB_PRINTF_FORMAT(2, 3);
+#define NOB_LOG_DECLARATION(nob_log_name) NOBDEF void nob_log_name(Nob_Log_Level level, const char *fmt, ...) NOB_PRINTF_FORMAT(2, 3)
+NOB_LOG_DECLARATION(nob_log);
+#ifdef NOB_LOG_CUSTOM_IMPLEMENTATION
+NOB_LOG_DECLARATION(nob_log_default);
+#endif
+#undef NOB_LOG_DECLARATION
 
 // It is an equivalent of shift command from bash (do `help shift` in bash). It basically
 // pops an element from the beginning of a sized array.
@@ -1504,7 +1511,13 @@ NOBDEF bool nob_cmd_run_sync_redirect_and_reset(Nob_Cmd *cmd, Nob_Cmd_Redirect r
     return nob_proc_wait(p);
 }
 
-NOBDEF void nob_log(Nob_Log_Level level, const char *fmt, ...)
+NOBDEF void
+#ifdef NOB_LOG_CUSTOM_IMPLEMENTATION
+nob_log_default
+#else
+nob_log
+#endif
+(Nob_Log_Level level, const char *fmt, ...)
 {
     if (level < nob_minimal_log_level) return;
 
@@ -2212,6 +2225,9 @@ NOBDEF int closedir(DIR *dirp)
         // NOTE: Name log is already defined in math.h and historically always was the natural logarithmic function.
         // So there should be no reason to strip the `nob_` prefix in this specific case.
         // #define log nob_log
+        #ifdef NOB_LOG_CUSTOM_IMPLEMENTATION
+            #define log_default nob_log_default
+        #endif // NOB_LOG_CUSTOM_IMPLEMENTATION
         #define shift nob_shift
         #define shift_args nob_shift_args
         #define File_Paths Nob_File_Paths

--- a/tests/nob_log_custom_implementation.c
+++ b/tests/nob_log_custom_implementation.c
@@ -1,0 +1,42 @@
+#define NOB_IMPLEMENTATION
+#define NOB_LOG_CUSTOM_IMPLEMENTATION
+#include "nob.h"
+
+const char * log_level_to_string_literal(Nob_Log_Level level)
+{
+    switch (level) {
+    case NOB_INFO:      return "INFO";
+    case NOB_WARNING:   return "WARNING";
+    case NOB_ERROR:     return "ERROR";
+    case NOB_NO_LOGS:   return "NO_LOGS";
+    default:            return "unknown";
+    }
+}
+
+// Custom implementation of nob_log
+void nob_log(Nob_Log_Level level, const char *fmt, ...)
+{
+    fprintf(stderr, "[CUSTOM] Persistent Custom Log Test Message (Level: %s)\n",
+        log_level_to_string_literal(level)
+    );
+
+    // You can still use the default implementation of nob_log
+    va_list args;
+    va_start(args, fmt);
+    nob_log_default(level, fmt, args);
+    va_end(args);
+}
+
+void log_test_messages(void)
+{
+    nob_log(NOB_INFO, "Info Test Message");
+    nob_log(NOB_WARNING, "Warning Test Message");
+    nob_log(NOB_ERROR, "Error Test Message");
+    nob_log(NOB_NO_LOGS, "YOU SHOULD NEVER SEE THIS");
+}
+
+int main(void)
+{
+    log_test_messages();
+    return 0;
+}


### PR DESCRIPTION
Implementation of issue #137

Adds flag `NOB_LOG_CUSTOM_IMPLEMENTATION`.

When defined it will declare the function `nob_log_default` which has the same signature as `nob_log`.
If `NOB_IMPLEMENTATION` is defined, the `nob_log` definition will be renamed to `nob_log_default`.
If `NOB_STRIP_PREFIX` is defined, `log_default` will become an alias for `nob_log_default`.

The user has to define and implement `nob_log` on their own after including `nob.h` with the `NOB_IMPLEMENTATION` and `NOB_LOG_CUSTOM_IMPLEMENTATION` flags set.
The original `nob_log` implementation is still accessible by the user via `nob_log_default`.