### PR TITLE
Handle EINTR error in waitpid call for POSIX

### DIFF
--- a/nob.h
+++ b/nob.h
@@ -1358,7 +1358,9 @@ NOBDEF bool nob_proc_wait(Nob_Proc proc)
 #else
     for (;;) {
         int wstatus = 0;
-        if (waitpid(proc, &wstatus, 0) < 0) {
+        int r = waitpid(proc, &wstatus, 0);
+        if (r < 0) {
+            if (r == -1 && errno == EINTR) continue; // continue if host process is interrupted
             nob_log(NOB_ERROR, "could not wait on command (pid %d): %s", proc, strerror(errno));
             return false;
         }


### PR DESCRIPTION
Using a debugger such as GDB or CodeLLDB on a program that uses `nob.h` and depends something like this:

```c
if (!nob_cmd_run(&cmd)) {
    fatal("Failed to run command");
  };
```

causes the debugging process to detach because of:
```
[ERROR] could not wait on command (pid 16237): Interrupted system call
```

This happens when a signal interrupts the waitpid() call, setting errno to EINTR.

This fix adds a retry logic for waitpid() to correctly handle EINTR, ensuring the command wait loop resumes normally instead of treating it as a fatal error.