### PR TITLE
Add incremental directory iterator

### DIFF
--- a/nob.h
+++ b/nob.h
@@ -2306,6 +2306,11 @@ NOBDEF int closedir(DIR *dirp)
         #define write_entire_file nob_write_entire_file
         #define get_file_type nob_get_file_type
         #define delete_file nob_delete_file
+        #define is_dir_empty nob_is_dir_empty
+        #define dir_iter_open nob_dir_iter_open
+        #define dir_iter_next nob_dir_iter_next
+        #define dir_iter_close nob_dir_iter_close
+        #define dir_iter_getname nob_dir_iter_getname
         #define return_defer nob_return_defer
         #define da_append nob_da_append
         #define da_free nob_da_free

--- a/nob.h
+++ b/nob.h
@@ -235,12 +235,6 @@ NOBDEF bool nob_write_entire_file(const char *path, const void *data, size_t siz
 NOBDEF Nob_File_Type nob_get_file_type(const char *path);
 NOBDEF bool nob_delete_file(const char *path);
 
-NOBDEF int  nob_is_dir_empty(const char *path);
-NOBDEF bool nob_dir_iter_open(Nob_Dir_Iter *iter, const char *path);
-NOBDEF bool nob_dir_iter_next(Nob_Dir_Iter *iter);
-NOBDEF bool nob_dir_iter_close(Nob_Dir_Iter **iter);
-NOBDEF char *nob_dir_iter_getname(Nob_Dir_Iter *iter);
-
 #define nob_return_defer(value) do { result = (value); goto defer; } while(0)
 
 // Initial capacity of a dynamic array
@@ -765,6 +759,18 @@ NOBDEF char *nob_win32_error_message(DWORD err);
 #endif // _WIN32
 
 #endif // NOB_H_
+
+typedef struct {
+    const char *path;
+    DIR *dir;
+    struct dirent *current;
+} Nob_Dir_Iter;
+
+NOBDEF int  nob_is_dir_empty(const char *path);
+NOBDEF bool nob_dir_iter_open(Nob_Dir_Iter *iter, const char *path);
+NOBDEF bool nob_dir_iter_next(Nob_Dir_Iter *iter);
+NOBDEF void nob_dir_iter_close(Nob_Dir_Iter **iter);
+NOBDEF char *nob_dir_iter_getname(Nob_Dir_Iter *iter);
 
 #ifdef NOB_IMPLEMENTATION
 


### PR DESCRIPTION
New functions in this PR:
- `nob_is_dir_empty()`
- `nob_dir_iter_open()`
- `nob_dir_iter_next()`
- `nob_dir_iter_close()`
- `nob_dir_iter_getname()`
New structure in this PR:
- `Nob_Dir_Iter`

Ues cases:
- Walking directory recusively
- Deleting directory recusively
- etc.

Example:
```c
Nob_Dir_Iter *iter = malloc(sizeof(Nob_Dir_Iter));
if (nob_dir_iter_open(&iter, "./src")) {
    while (nob_dir_iter_next(&iter)) {
        const char *name = nob_dir_iter_getname(&iter);
        // processing
    }
    nob_dir_iter_close(&iter);
}
```