### PR TITLE
Add recursive directory deletion

### DIFF
--- a/nob.h
+++ b/nob.h
@@ -2306,6 +2306,11 @@ NOBDEF int closedir(DIR *dirp)
         #define write_entire_file nob_write_entire_file
         #define get_file_type nob_get_file_type
         #define delete_file nob_delete_file
+        #define is_dir_empty nob_is_dir_empty
+        #define dir_iter_open nob_dir_iter_open
+        #define dir_iter_next nob_dir_iter_next
+        #define dir_iter_close nob_dir_iter_close
+        #define dir_iter_getname nob_dir_iter_getname
         #define return_defer nob_return_defer
         #define da_append nob_da_append
         #define da_free nob_da_free

--- a/nob.h
+++ b/nob.h
@@ -235,12 +235,6 @@ NOBDEF bool nob_write_entire_file(const char *path, const void *data, size_t siz
 NOBDEF Nob_File_Type nob_get_file_type(const char *path);
 NOBDEF bool nob_delete_file(const char *path);
 
-NOBDEF int  nob_is_dir_empty(const char *path);
-NOBDEF bool nob_dir_iter_open(Nob_Dir_Iter *iter, const char *path);
-NOBDEF bool nob_dir_iter_next(Nob_Dir_Iter *iter);
-NOBDEF bool nob_dir_iter_close(Nob_Dir_Iter **iter);
-NOBDEF char *nob_dir_iter_getname(Nob_Dir_Iter *iter);
-
 #define nob_return_defer(value) do { result = (value); goto defer; } while(0)
 
 // Initial capacity of a dynamic array
@@ -765,6 +759,18 @@ NOBDEF char *nob_win32_error_message(DWORD err);
 #endif // _WIN32
 
 #endif // NOB_H_
+
+typedef struct {
+    const char *path;
+    DIR *dir;
+    struct dirent *current;
+} Nob_Dir_Iter;
+
+NOBDEF int  nob_is_dir_empty(const char *path);
+NOBDEF bool nob_dir_iter_open(Nob_Dir_Iter *iter, const char *path);
+NOBDEF bool nob_dir_iter_next(Nob_Dir_Iter *iter);
+NOBDEF void nob_dir_iter_close(Nob_Dir_Iter **iter);
+NOBDEF char *nob_dir_iter_getname(Nob_Dir_Iter *iter);
 
 #ifdef NOB_IMPLEMENTATION
 


### PR DESCRIPTION
Related PRs:
- #103 
- #145 

Related commits:
- #88 (close it)

This PR features a recursive directory deletion to `nob.h` based on the incremental directory iterator in #145, which is built upon DFS and its time complexity is `O(n)` (more exactly, `O(f + d)`, `f` as number of files, `d` as number of directories).

New functions:
- [API] `nob_delete_directory()`: deletes empty directories
- [API] `nob_delete_directory_recursively()`: deletes directories recursively
- [INNER] `nob__delete_directory_recursively()`: implementation of `nob_delete_directory_recursively()`

Example:
```c
nob_delete_directory_recursively("./build");
nob_delete_directory_recursively("./bin");
nob_delete_directory_recursively("./obj");
// etc.
```