### PR TITLE
allow changing working directory for child processes

### DIFF
--- a/nob.c
+++ b/nob.c
@@ -41,10 +41,8 @@ bool build_and_run_test(Cmd *cmd, const char *test_name)
 
     const char *test_cwd_path = temp_sprintf("%s%s%s.cwd", BUILD_FOLDER, TESTS_FOLDER, test_name);
     if (!mkdir_if_not_exists(test_cwd_path)) return false;
-    if (!set_current_dir(test_cwd_path)) return false;
-    cmd_append(cmd, temp_sprintf("../%s", test_name));
-    if (!cmd_run(cmd))    return false;
-    if (!set_current_dir("../../../")) return false;
+    cmd_append(cmd, temp_sprintf("%s%s%s", BUILD_FOLDER, TESTS_FOLDER, test_name));
+    if (!cmd_run(cmd, .pwd = test_cwd_path))    return false;
 
     nob_log(INFO, "--- %s finished ---", bin_path);
 


### PR DESCRIPTION
only windows is implemented yet

I thought that linux would let you do `chdir` before `execvp` but that means relative paths are no long relative to the current original directory. 