### PR TITLE
add /Fo flag to msvc to move output obj files to build folder

### DIFF
--- a/nob.h
+++ b/nob.h
@@ -588,7 +588,7 @@ NOBDEF bool nob_set_current_dir(const char *path);
 
 #ifndef nob_cc_output
 #  if defined(_MSC_VER) && !defined(__clang__)
-#    define nob_cc_output(cmd, output_path) nob_cmd_append(cmd, nob_temp_sprintf("/Fe:%s", (output_path)))
+#    define nob_cc_output(cmd, output_path) nob_cmd_append(cmd, nob_temp_sprintf("/Fe:%s", (output_path)), nob_temp_sprintf("/Fo:%s", (output_path)))
 #  else
 #    define nob_cc_output(cmd, output_path) nob_cmd_append(cmd, "-o", (output_path))
 #  endif


### PR DESCRIPTION
add /Fo flag to msvc to stop it from polluting the working directory with obj files