### PR TITLE
Fix build while using -pedantic flag

### DIFF
--- a/nob.h
+++ b/nob.h
@@ -431,7 +431,7 @@ NOBDEF uint64_t nob_nanos_since_unspecified_epoch(void);
 
 // Same as nob_cmd_run_opt but using cool variadic macro to set the default options.
 // See https://x.com/vkrajacic/status/1749816169736073295 for more info on how to use such macros.
-#define nob_cmd_run(cmd, ...) nob_cmd_run_opt((cmd), (Nob_Cmd_Opt){__VA_ARGS__})
+#define nob_cmd_run(cmd, ...) nob_cmd_run_opt((cmd), (Nob_Cmd_Opt){.async = NULL, __VA_ARGS__})
 
 // DEPRECATED:
 //


### PR DESCRIPTION
With `-pedantic` flag I got following compiler warning:
```
../nob.h:434:67: warning: ISO C forbids empty initializer braces before C23 [-Wpedantic]
  434 | #define nob_cmd_run(cmd, ...) nob_cmd_run_opt((cmd), (Nob_Cmd_Opt){__VA_ARGS__})
      |                                                                   ^
```
It's even worse with `-Werror` flag.

This PR aims to fix this problem by adding default value for one of options (I chose `async` since it's first argument).