### PR TITLE
Fix _NSGetExecutablePath() forward declaration error

### DIFF
--- a/nob.h
+++ b/nob.h
@@ -1,4 +1,4 @@
-/* nob - v1.25.0 - Public Domain - https://github.com/tsoding/nob.h
+/* nob - v1.25.1 - Public Domain - https://github.com/tsoding/nob.h
 
    This library is the next generation of the [NoBuild](https://github.com/tsoding/nobuild) idea.
 
@@ -2449,6 +2449,7 @@ NOBDEF int closedir(DIR *dirp)
 /*
    Revision history:
 
+     1.25.1 (2025-11-06) Fix forward declaration of _NSGetExecutablePath on MacOS (by agss0)
      1.25.0 (2025-10-25)   - Add nob_sb_pad_align()
                            - Add nob_swap()
                            - Add nob_temp_strndup()


### PR DESCRIPTION
The `nob_temp_running_executable_path()` calls `_NSGetExecutablePath` in MacOS:

```c
NOBDEF char *nob_temp_running_executable_path(void)
{
    ...
#elif defined(__APPLE__)
    char buf[4096];
    uint32_t size = NOB_ARRAY_LEN(buf);
    if (_NSGetExecutablePath(buf, &size) != 0) return "";
    int length = strlen(buf);
    return nob_temp_strndup(buf, length);
#else
    ...
}
```

Which is declared in `mach-o/dyld.h`
```
error: call to undeclared function '_NSGetExecutablePath'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
 2227 |     if (_NSGetExecutablePath(buf, &size) != 0) return "";
      |         ^
1 error generated.
```