### PR TITLE
Add option to not reset the command after execution

### DIFF
--- a/nob.h
+++ b/nob.h
@@ -413,6 +413,8 @@ typedef struct {
     Nob_Procs *async;
     // Maximum processes allowed in the .async list. Zero implies nob_nprocs().
     size_t max_procs;
+    // Do not reset the command after execution.
+    bool keep_cmd;
     // Redirect stdin to file
     const char *stdin_path;
     // Redirect stdout to file
@@ -1104,7 +1106,7 @@ defer:
     if (opt_fdin)  nob_fd_close(*opt_fdin);
     if (opt_fdout) nob_fd_close(*opt_fdout);
     if (opt_fderr) nob_fd_close(*opt_fderr);
-    cmd->count = 0;
+    if (!opt.keep_cmd) cmd->count = 0;
     return result;
 }
 


### PR DESCRIPTION
A missing feature from the new API that was available on the deprecated one, is the ability to execute the commands without reseting the memory associated with them. While in many cases just firing the command and reusing the memory for the next is sufficient, there are situations where we might want to keep the command data.

My use case scenario for this functionality is using the commands that were executed successfully to generate a compile_commands.json file for the project afterwards (which is useful for people using LSPs).