### PR TITLE
Assume build.conf not exists if build file found instead of directory

### DIFF
--- a/nob.h
+++ b/nob.h
@@ -2097,7 +2097,8 @@ NOBDEF int nob_file_exists(const char *file_path)
 #else
     struct stat statbuf;
     if (stat(file_path, &statbuf) < 0) {
-        if (errno == ENOENT) return 0;
+        if (errno == ENOENT)  return 0;
+        if (errno == ENOTDIR) return 0;
         nob_log(NOB_ERROR, "Could not check if file %s exists: %s", file_path, strerror(errno));
         return -1;
     }


### PR DESCRIPTION
My attempt to build the build script with `cc nob.c -o build && ./build` ended up with
[ERROR] Could not check if file ./build/build.conf exists: Not a directory
This encounter is odd for fresh builds, since there is no chance of having `build` directory anyway.

To mitigate this ambiguity, I propose an additional check if `errno` is `ENOTDIR`, so a file `build` will not be confused with directory of old configuration scheme.