### PR TITLE
strip prefix from usefull functions and macros

### DIFF
--- a/nob.c
+++ b/nob.c
@@ -36,10 +36,10 @@ bool build_and_run_test(Cmd *cmd, const char *test_name)
 
     const char *bin_path = temp_sprintf("%s%s", BUILD_FOLDER TESTS_FOLDER, test_name);
     const char *src_path = temp_sprintf("%s%s.c", TESTS_FOLDER, test_name);
-    nob_cc(cmd);
-    nob_cc_flags(cmd);
-    nob_cc_output(cmd, bin_path);
-    nob_cc_inputs(cmd, src_path);
+    cc(cmd);
+    cc_flags(cmd);
+    cc_output(cmd, bin_path);
+    cc_inputs(cmd, src_path);
     if (!cmd_run(cmd)) return false;
 
     const char *test_cwd_path = temp_sprintf("%s%s%s.cwd", BUILD_FOLDER, TESTS_FOLDER, test_name);
@@ -59,7 +59,7 @@ int main(int argc, char **argv)
 {
     set_log_handler(cancer_log_handler);
 
-    NOB_GO_REBUILD_URSELF_PLUS(argc, argv, "nob.h", "shared.h");
+    GO_REBUILD_URSELF_PLUS(argc, argv, "nob.h", "shared.h");
 
     Cmd cmd = {0};
 

--- a/nob.h
+++ b/nob.h
@@ -2410,6 +2410,8 @@ NOBDEF int closedir(DIR *dirp)
         #define shift nob_shift
         #define shift_args nob_shift_args
         #define File_Paths Nob_File_Paths
+        #define GO_REBUILD_URSELF NOB_GO_REBUILD_URSELF
+        #define GO_REBUILD_URSELF_PLUS NOB_GO_REBUILD_URSELF_PLUS
         #define FILE_REGULAR NOB_FILE_REGULAR
         #define FILE_DIRECTORY NOB_FILE_DIRECTORY
         #define FILE_SYMLINK NOB_FILE_SYMLINK
@@ -2453,6 +2455,10 @@ NOBDEF int closedir(DIR *dirp)
         #define procs_wait_and_reset nob_procs_wait_and_reset
         #define procs_append_with_flush nob_procs_append_with_flush
         #define procs_flush nob_procs_flush
+        #define cc nob_cc
+        #define cc_flags nob_cc_flags
+        #define cc_inputs nob_cc_inputs
+        #define cc_output nob_cc_output
         #define Cmd Nob_Cmd
         #define Cmd_Redirect Nob_Cmd_Redirect
         #define Cmd_Opt Nob_Cmd_Opt


### PR DESCRIPTION
strip prefix from:


- GO_REBUILD_URSELF
- GO_REBUILD_URSELF_PLUS

- nob_cc
- nob_flags
- nob_cc_inputs
- nob_cc_output

and make nob.c adheres to them.