### PR TITLE
Fix support for FreeBSD

### DIFF
--- a/nob.h
+++ b/nob.h
@@ -166,6 +166,9 @@
 #    ifdef __APPLE__
 #        include <mach-o/dyld.h>
 #    endif
+#    ifdef __FreeBSD__
+#        include <sys/sysctl.h>
+#    endif
 #    include <sys/types.h>
 #    include <sys/wait.h>
 #    include <sys/stat.h>
@@ -2283,6 +2286,12 @@ NOBDEF char *nob_temp_running_executable_path(void)
     uint32_t size = NOB_ARRAY_LEN(buf);
     if (_NSGetExecutablePath(buf, &size) != 0) return "";
     int length = strlen(buf);
+    return nob_temp_strndup(buf, length);
+#elif defined(__FreeBSD__)
+    char buf[4096];
+    int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1 };
+    size_t length = sizeof(buf);
+    if (sysctl(mib, 4, buf, &length, NULL, 0) < 0) return "";
     return nob_temp_strndup(buf, length);
 #else
     fprintf(stderr, "%s:%d: TODO: nob_temp_running_executable_path is not implemented for this platform\n", __FILE__, __LINE__);

--- a/shared.h
+++ b/shared.h
@@ -16,6 +16,9 @@
 // TODO: "-std=c99", "-D_POSIX_C_SOURCE=200112L" didn't work for MacOS, don't know why, don't really care that much at the moment.
 //   Anybody who does feel free to investigate.
 #  define nob_cc_flags(cmd) cmd_append(cmd, "-Wall", "-Wextra", "-Wswitch-enum", "-I.")
+#elif defined(__FreeBSD__)
+// "-D_POSIX_C_SOURCE=200112L" hides required symbols on FreeBSD
+#  define nob_cc_flags(cmd) cmd_append(cmd, "-Wall", "-Wextra", "-Wswitch-enum", "-std=c99", "-ggdb", "-I.");
 #else
 #  define nob_cc_flags(cmd) cmd_append(cmd, "-Wall", "-Wextra", "-Wswitch-enum", "-std=c99", "-D_POSIX_C_SOURCE=200112L", "-ggdb", "-I.");
 #endif


### PR DESCRIPTION
This only requires a very simple implementation of `nob_temp_running_executable_path` and changing the compile flags a tiny bit because using `-D_POSIX_C_SOURCE=200112L` hides `_SC_NPROCESSORS_ONLN` which is used in `nob.h`