### PR TITLE
Fix MSVC warning.

### DIFF
--- a/how_to/001_basic_usage/nob.c
+++ b/how_to/001_basic_usage/nob.c
@@ -50,7 +50,7 @@ int main(int argc, char **argv)
     nob_cmd_append(&cmd, "cc", "-Wall", "-Wextra", "-o", BUILD_FOLDER"hello", SRC_FOLDER"hello.c");
 #else
     // On MSVC
-    nob_cmd_append(&cmd, "cl", "-I.", "-o", BUILD_FOLDER"hello", SRC_FOLDER"hello.c");
+    nob_cmd_append(&cmd, "cl", "-I.", "/Fe:"BUILD_FOLDER"hello", SRC_FOLDER"hello.c");
 #endif // _MSC_VER
 
     // Let's execute the command.


### PR DESCRIPTION
Fixes problem described in https://github.com/tsoding/nob.h/issues/183.

Before:

```
c:\path\to\nob.h\how_to\001_basic_usage
>cl nob.c
Microsoft (R) C/C++ Optimizing Compiler Version 19.50.35721 for x86
Copyright (C) Microsoft Corporation.  All rights reserved.

nob.c
Microsoft (R) Incremental Linker Version 14.50.35721.0
Copyright (C) Microsoft Corporation.  All rights reserved.

/out:nob.exe
nob.obj

c:\path\to\nob.h\how_to\001_basic_usage
>nob.exe
[INFO] created directory `build/`
[INFO] CMD: cl -I. -o build/hello src/hello.c
Microsoft (R) C/C++ Optimizing Compiler Version 19.50.35721 for x86
Copyright (C) Microsoft Corporation.  All rights reserved.

cl : Command line warning D9035 : option 'o' has been deprecated and will be removed in a future release
hello.c
Microsoft (R) Incremental Linker Version 14.50.35721.0
Copyright (C) Microsoft Corporation.  All rights reserved.

/out:hello.exe
/out:build/hello.exe
hello.obj
[INFO] CMD: cl.exe /W4 /nologo /D_CRT_SECURE_NO_WARNINGS /Fe:build/foo /Fo:build/foo src/foo.c
foo.c

c:\path\to\nob.h\how_to\001_basic_usage
>build\hello.exe
Hello, World

c:\path\to\nob.h\how_to\001_basic_usage
>build\foo.exe
Foo, bar

c:\path\to\nob.h\how_to\001_basic_usage
>
```

After:

```
c:\path\to\nob.h\how_to\001_basic_usage
>cl nob.c
Microsoft (R) C/C++ Optimizing Compiler Version 19.50.35721 for x86
Copyright (C) Microsoft Corporation.  All rights reserved.

nob.c
Microsoft (R) Incremental Linker Version 14.50.35721.0
Copyright (C) Microsoft Corporation.  All rights reserved.

/out:nob.exe
nob.obj

c:\path\to\nob.h\how_to\001_basic_usage
>nob.exe
[INFO] created directory `build/`
[INFO] CMD: cl -I. /Fe:build/hello src/hello.c
Microsoft (R) C/C++ Optimizing Compiler Version 19.50.35721 for x86
Copyright (C) Microsoft Corporation.  All rights reserved.

hello.c
Microsoft (R) Incremental Linker Version 14.50.35721.0
Copyright (C) Microsoft Corporation.  All rights reserved.

/out:build/hello.exe
hello.obj
[INFO] CMD: cl.exe /W4 /nologo /D_CRT_SECURE_NO_WARNINGS /Fe:build/foo /Fo:build/foo src/foo.c
foo.c

c:\path\to\nob.h\how_to\001_basic_usage
>build\hello.exe
Hello, World

c:\path\to\nob.h\how_to\001_basic_usage
>build\foo.exe
Foo, bar

c:\path\to\nob.h\how_to\001_basic_usage
>
```
