### PR TITLE
Fix MSVC warnings.

### DIFF
--- a/nob.h
+++ b/nob.h
@@ -2118,14 +2118,14 @@ NOBDEF bool nob_read_entire_file(const char *path, Nob_String_Builder *sb)
     if (m < 0)                     nob_return_defer(false);
     if (fseek(f, 0, SEEK_SET) < 0) nob_return_defer(false);
 
-    new_count = sb->count + m;
+    new_count = sb->count + (size_t)m;
     if (new_count > sb->capacity) {
         sb->items = NOB_DECLTYPE_CAST(sb->items)NOB_REALLOC(sb->items, new_count);
         NOB_ASSERT(sb->items != NULL && "Buy more RAM lool!!");
         sb->capacity = new_count;
     }
 
-    fread(sb->items + sb->count, m, 1, f);
+    fread(sb->items + sb->count, (size_t)m, 1, f);
     if (ferror(f)) {
         // TODO: Afaik, ferror does not set errno. So the error reporting in defer is not correct in this case.
         nob_return_defer(false);


### PR DESCRIPTION
Fix MSVC warnings described in https://github.com/tsoding/nob.h/issues/185.

Before:

```
c:\path\to\nob.h\how_to\010_nob_two_stage
>cl nob.c
Microsoft (R) C/C++ Optimizing Compiler Version 19.50.35721 for x86
Copyright (C) Microsoft Corporation.  All rights reserved.

nob.c
Microsoft (R) Incremental Linker Version 14.50.35721.0
Copyright (C) Microsoft Corporation.  All rights reserved.

/out:nob.exe
nob.obj

c:\path\to\nob.h\how_to\010_nob_two_stage
>nob.exe
[INFO] created directory `build/`
[INFO] Generating initial build/config.h
[INFO] ==================================
[INFO] EDIT build/config.h TO CONFIGURE YOUR BUILD!!!
[INFO] ==================================
[INFO] CMD: cl.exe /W4 /nologo /D_CRT_SECURE_NO_WARNINGS -I. -Ibuild/ -Isrc_build/ /Fe:build/nob_configed /Fo:build/nob_configed src_build/nob_configed.c
nob_configed.c
.\nob.h(2090): warning C4244: '=': conversion from '__int64' to 'size_t', possible loss of data
.\nob.h(2097): warning C4244: 'function': conversion from '__int64' to 'size_t', possible loss of data
[INFO] CMD: build/nob_configed
[INFO] CMD: cl.exe /W4 /nologo /D_CRT_SECURE_NO_WARNINGS -Ibuild/ -I. /Fe:build/main /Fo:build/main src/main.c
main.c

c:\path\to\nob.h\how_to\010_nob_two_stage
>build\main.exe
Hello, World

c:\path\to\nob.h\how_to\010_nob_two_stage
>
```

After:

```
c:\path\to\nob.h\how_to\010_nob_two_stage
>cl nob.c
Microsoft (R) C/C++ Optimizing Compiler Version 19.50.35721 for x86
Copyright (C) Microsoft Corporation.  All rights reserved.

nob.c
Microsoft (R) Incremental Linker Version 14.50.35721.0
Copyright (C) Microsoft Corporation.  All rights reserved.

/out:nob.exe
nob.obj

c:\path\to\nob.h\how_to\010_nob_two_stage
>nob.exe
[INFO] created directory `build/`
[INFO] Generating initial build/config.h
[INFO] ==================================
[INFO] EDIT build/config.h TO CONFIGURE YOUR BUILD!!!
[INFO] ==================================
[INFO] CMD: cl.exe /W4 /nologo /D_CRT_SECURE_NO_WARNINGS -I. -Ibuild/ -Isrc_build/ /Fe:build/nob_configed /Fo:build/nob_configed src_build/nob_configed.c
nob_configed.c
[INFO] CMD: build/nob_configed
[INFO] CMD: cl.exe /W4 /nologo /D_CRT_SECURE_NO_WARNINGS -Ibuild/ -I. /Fe:build/main /Fo:build/main src/main.c
main.c

c:\path\to\nob.h\how_to\010_nob_two_stage
>build\main.exe
Hello, World

c:\path\to\nob.h\how_to\010_nob_two_stage
>
```
