### PR TITLE
Fix compiler flags for MSVC Clang

### DIFF
--- a/shared.h
+++ b/shared.h
@@ -11,7 +11,11 @@
 // TODO: we should test on C++ compilers too
 
 #if defined(_MSC_VER)
-#  define nob_cc_flags(cmd) cmd_append(cmd, "/W4", "/nologo", "/D_CRT_SECURE_NO_WARNINGS", "-I.")
+#  if !defined(__clang__)
+#    define nob_cc_flags(cmd) cmd_append(cmd, "/W4", "/nologo", "/D_CRT_SECURE_NO_WARNINGS", "-I.")
+#  else
+#    define nob_cc_flags(cmd) cmd_append(cmd, "-Wall", "-Wextra", "-Wswitch-enum", "-std=c99", "-g", "-D_CRT_SECURE_NO_WARNINGS", "-I.")
+#  endif
 #elif defined(__APPLE__) || defined(__MACH__)
 // TODO: "-std=c99", "-D_POSIX_C_SOURCE=200112L" didn't work for MacOS, don't know why, don't really care that much at the moment.
 //   Anybody who does feel free to investigate.


### PR DESCRIPTION
Fix incorrect flags when compiling nob.c with MSVC Clang

Expected:
```
ℹ️ [INFO] CMD: clang -Wall -Wextra -Wswitch-enum -std=c99 -g -D_CRT_SECURE_NO_WARNINGS -I. -o build/tests/minimal_log_level tests/minimal_log_level.c
```

Actual:
```
ℹ️ [INFO] CMD: clang /W4 /nologo /D_CRT_SECURE_NO_WARNINGS -I. -o build/tests/minimal_log_level tests/minimal_log_level.c
clang: error: no such file or directory: '/W4'
clang: error: no such file or directory: '/nologo'
clang: error: no such file or directory: '/D_CRT_SECURE_NO_WARNINGS'
🚨 [ERROR] command exited with exit code 1
🚨 [ERROR] command exited with exit code 1
```

Those flags would work in `clang-cl`, but i didnt found a way to differentiate those two