### PR TITLE
Predeclare nob__cmd_append in the header section

### DIFF
--- a/nob.h
+++ b/nob.h
@@ -907,6 +907,7 @@ NOBDEF char *nob_win32_error_message(DWORD err);
 
 #endif // _WIN32
 
+void nob__cmd_append(Nob_Cmd *cmd, size_t n, ...);
 #endif // NOB_H_
 
 #ifdef NOB_IMPLEMENTATION


### PR DESCRIPTION
In my project multiple files include nob.h.

I like to add `#define *_IMPLEMENTATION` at the end of main.c, just to not need to `#undef` it and to keep the file tidy.

My usage:
```
#include "example.h" // includes nob.h

...
int main(void) { ... }

#define NOB_IMPLEMENTATION
#include "nob.h"
```

The issue is that this way `example.h` is not able to expand the  macro `cmd_append`, since the `nob__cmd_append` is not yet declared.

Of course the issue is not present if you are a normal person and don't exercise a particular code style:
```
#define NOB_IMPLEMENTATION
#include "nob.h"
#undef NOB_IMPLEMENTATION
#include "example.h"
```

But since this does not affect anything, I believe `nob__cmd_append` should just be pre-declared in nob.h's in its header section.

Cheers!