### PR TITLE
[nob.h] undefine NOB_IMPLEMENTATION

### DIFF
--- a/nob.h
+++ b/nob.h
@@ -957,6 +957,7 @@ NOBDEF char *nob_win32_error_message(DWORD err);
 #endif // NOB_H_
 
 #ifdef NOB_IMPLEMENTATION
+#undef NOB_IMPLEMENTATION
 
 // This is like nob_proc_wait() but waits asynchronously. Depending on the platform ms means different thing.
 // On Windows it means timeout. On POSIX it means for how long to sleep after checking if the process exited,


### PR DESCRIPTION
Undefine implementation macro after passning the #ifdef to prevent certain types of include errors.

If a header file that include nob.h is include after includation of nob.h that has an implementation, it would caused redefition errors.