### PR TITLE
Fix overriding of C++11's std::swap function

### DIFF
--- a/nob.h
+++ b/nob.h
@@ -3022,6 +3022,12 @@ NOBDEF char *nob_temp_running_executable_path(void)
         #define nprocs nob_nprocs
         #define nanos_since_unspecified_epoch nob_nanos_since_unspecified_epoch
         #define NANOS_PER_SEC NOB_NANOS_PER_SEC
+
+        // On C++, this will cause a failur of compilation if nob.h is included before
+        // things like `<algorithm>' or `<string_view>' because of `std::swap'
+        #if defined(__cplusplus)
+            #undef swap
+        #endif
     #endif // NOB_STRIP_PREFIX
 #endif // NOB_STRIP_PREFIX_GUARD_
 


### PR DESCRIPTION
the nob_swap macro from [v1.25.0](https://github.com/tsoding/nob.h/commit/0b71f92ed12888949aa53afa27a74fd71c3525a2#diff-019b67d129a52f1af22135776abf9bcb643e5e5816e4722a8eaf0c598cfce35fR2368) redefines `std::swap()` causing a nasty (standard) long compile error about incorrect arguments to std::swap() in other C++ stdlib headers since C++ is ~~bad~~ good.

I think simply having a conditional at the end of the `NOB_STRIP_PREFIX` is best, unless there's a point else where we deal with un-definitions of macros I didn't spot- minor issue really.