### PR TITLE
fix for #243

### DIFF
--- a/nob.c
+++ b/nob.c
@@ -172,6 +172,10 @@ extern "C" {
 }
 #endif
 
+#ifdef _WIN32
+#include "ConsoleApi2.h"
+#endif // _WIN32
+
 int main(int argc, char **argv)
 {
 #ifdef _WIN32

--- a/nob.h
+++ b/nob.h
@@ -1076,10 +1076,25 @@ static char nob_temp[NOB_TEMP_CAPACITY] = {0};
 NOBDEF bool nob_mkdir_if_not_exists(const char *path)
 {
 #ifdef _WIN32
-    int result = _mkdir(path);
+    WCHAR utf16_buffer[MAX_PATH];
+    int n = MultiByteToWideChar(CP_UTF8, 0, path, -1, utf16_buffer, sizeof(utf16_buffer));
+    if(n == 0){
+        nob_log(NOB_ERROR, "Could not convert dir_path name from utf8 to utf16: %s", nob_win32_error_message(GetLastError()));
+        return false;
+    }
+    
+    int result = CreateDirectoryW(utf16_buffer, NULL);
+    if(result == 0){
+      if(GetLastError() == ERROR_ALREADY_EXISTS){
+        nob_log(NOB_INFO, "directory `%s` already exists", path);
+        return true;
+      }else{
+        nob_log(NOB_ERROR, "Could not create directory: %s", nob_win32_error_message(GetLastError()));
+        return false;
+      }
+    }
 #else
     int result = mkdir(path, 0755);
-#endif
     if (result < 0) {
         if (errno == EEXIST) {
 #ifndef NOB_NO_ECHO
@@ -1090,6 +1105,7 @@ NOBDEF bool nob_mkdir_if_not_exists(const char *path)
         nob_log(NOB_ERROR, "could not create directory `%s`: %s", path, strerror(errno));
         return false;
     }
+#endif
 
 #ifndef NOB_NO_ECHO
     nob_log(NOB_INFO, "created directory `%s`", path);
@@ -2160,7 +2176,18 @@ NOBDEF bool nob_write_entire_file(const char *path, const void *data, size_t siz
     bool result = true;
 
     const char *buf = NULL;
+#ifdef _WIN32
+    WCHAR utf16_buffer[MAX_PATH];
+    int n = MultiByteToWideChar(CP_UTF8, 0, path, -1, utf16_buffer, sizeof(utf16_buffer));
+    if(n == 0){
+        nob_log(NOB_ERROR, "Could not convert dir_path name from utf8 to utf16: %s", nob_win32_error_message(GetLastError()));
+        return false;
+    }
+
+    FILE* f = _wfopen(utf16_buffer, L"wb");
+#else
     FILE *f = fopen(path, "wb");
+#endif
     if (f == NULL) {
         nob_log(NOB_ERROR, "Could not open file %s for writing: %s\n", path, strerror(errno));
         nob_return_defer(false);
@@ -2497,7 +2524,17 @@ NOBDEF bool nob_read_entire_file(const char *path, Nob_String_Builder *sb)
 {
     bool result = true;
 
+#ifdef _WIN32
+    WCHAR wpath[MAX_PATH];
+    int n = MultiByteToWideChar(CP_UTF8, 0, path, -1, wpath, sizeof(wpath));
+    if(n == 0){
+        nob_log(NOB_ERROR, "Could not convert dir_path name from utf8 to utf16: %s", nob_win32_error_message(GetLastError()));
+        return false;
+    }
+    FILE *f = _wfopen(wpath, L"rb");
+#else
     FILE *f = fopen(path, "rb");
+#endif
     size_t new_count = 0;
     long long m = 0;
     if (f == NULL)                 nob_return_defer(false);
@@ -2740,16 +2777,16 @@ NOBDEF const char *nob_get_current_dir_temp(void)
         return NULL;
     }
 
-    LPWSTR utf16_buffer;
-    utf16_buffer = (LPWSTR) nob_temp_alloc(nBufferLength*sizeof(*utf16_buffer));
+    LPWSTR wpath;
+    wpath = (LPWSTR) nob_temp_alloc(nBufferLength*sizeof(*wpath));
 
-    if (GetCurrentDirectoryW(nBufferLength, utf16_buffer) == 0) {
+    if (GetCurrentDirectoryW(nBufferLength, wpath) == 0) {
         nob_log(NOB_ERROR, "could not get current directory: %s", nob_win32_error_message(GetLastError()));
         return NULL;
     }
 
 
-    int nUtf8BufferLength = WideCharToMultiByte(CP_UTF8, 0, utf16_buffer, nBufferLength, NULL, 0, NULL, NULL);
+    int nUtf8BufferLength = WideCharToMultiByte(CP_UTF8, 0, wpath, nBufferLength, NULL, 0, NULL, NULL);
     if(nUtf8BufferLength == 0){
       nob_log(NOB_ERROR, "Could not determine utf8 path size: %s", nob_win32_error_message(GetLastError()));
       return NULL;
@@ -2758,7 +2795,7 @@ NOBDEF const char *nob_get_current_dir_temp(void)
     char* buffer;
     buffer = (char*) nob_temp_alloc(nUtf8BufferLength*sizeof(*buffer));
     
-    nUtf8BufferLength = WideCharToMultiByte(CP_UTF8, 0, utf16_buffer, nBufferLength, buffer, nUtf8BufferLength, NULL, NULL);
+    nUtf8BufferLength = WideCharToMultiByte(CP_UTF8, 0, wpath, nBufferLength, buffer, nUtf8BufferLength, NULL, NULL);
     if(nBufferLength == 0){
       nob_log(NOB_ERROR, "Could not convert utf16 path to utf8: %s", nob_win32_error_message(GetLastError()));
       return NULL;

--- a/nob.h
+++ b/nob.h
@@ -308,12 +308,12 @@ NOBDEF bool nob_walk_dir_opt(const char *root, Nob_Walk_Func func, Nob_Walk_Dir_
 #define nob_walk_dir(root, func, ...) nob_walk_dir_opt((root), (func), NOB_CLIT(Nob_Walk_Dir_Opt){__VA_ARGS__})
 
 typedef struct {
-    char *name;
+    const char *name;
     bool error;
 
     struct {
 #ifdef _WIN32
-        WIN32_FIND_DATA win32_data;
+        WIN32_FIND_DATAW win32_data;
         HANDLE win32_hFind;
         bool win32_init;
 #else
@@ -951,6 +951,7 @@ NOBDEF Nob_String_View nob_sv_from_parts(const char *data, size_t count);
 #ifdef _WIN32
 
 NOBDEF char *nob_win32_error_message(DWORD err);
+NOBDEF LPCWSTR nob_win32_temp_utf8_to_utf16(const char* str);
 
 #endif // _WIN32
 
@@ -1012,6 +1013,50 @@ NOBDEF char *nob_win32_error_message(DWORD err) {
     }
 
     return win32ErrMsg;
+}
+
+// https://learn.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-multibytetowidechar
+NOBDEF LPCWSTR nob_win32_temp_utf8_to_utf16(const char* str){
+
+  // n is the output strings size in charachters and includes size for null terminator due to -1
+  int n = MultiByteToWideChar(CP_UTF8, 0, str, -1, NULL, 0);
+  if(n == 0){
+    nob_log(NOB_ERROR, "Could not determine charachter count for utf8 to utf16 conversion: %s", nob_win32_error_message(GetLastError()));
+    return NULL;
+  }
+
+  LPWSTR wstr;
+  wstr = nob_temp_alloc(n*sizeof(*wstr));
+
+  n = MultiByteToWideChar(CP_UTF8, 0, str, -1, wstr, n);
+  if(n == 0){
+    nob_log(NOB_ERROR, "Could not convert utf8 to utf16: %s", nob_win32_error_message(GetLastError()));
+    return NULL;
+  }
+
+  return wstr;
+}
+
+// https://learn.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-widechartomultibyte
+NOBDEF const char* nob_win32_temp_utf16_to_utf8(LPCWSTR wstr){
+
+  // n is the output strings size in bytes and includes size for null terminator due to -1
+  int n = WideCharToMultiByte(CP_UTF8, 0, wstr, -1, NULL, 0, NULL, NULL);
+  if(n == 0){
+    nob_log(NOB_ERROR, "Could not determine byte count for utf16 to utf8 conversion: %s", nob_win32_error_message(GetLastError()));
+    return NULL;
+  }
+
+  char* str;
+  str = nob_temp_alloc(n*sizeof(*str));
+
+  n = WideCharToMultiByte(CP_UTF8, 0, wstr, -1, str, n, NULL, NULL);
+  if(n == 0){
+    nob_log(NOB_ERROR, "Could not convert utf16 to utf8: %s", nob_win32_error_message(GetLastError()));
+    return NULL;
+  }
+
+  return str;
 }
 
 #endif // _WIN32
@@ -1218,6 +1263,7 @@ static void nob__win32_cmd_quote(Nob_Cmd cmd, Nob_String_Builder *quoted)
         }
     }
 }
+
 #endif
 
 NOBDEF int nob_nprocs(void)
@@ -1959,8 +2005,8 @@ NOBDEF bool nob_dir_entry_open(const char *dir_path, Nob_Dir_Entry *dir)
     memset(dir, 0, sizeof(*dir));
 #ifdef _WIN32
     size_t temp_mark = nob_temp_save();
-    char *buffer = nob_temp_sprintf("%s\\*", dir_path);
-    dir->nob__private.win32_hFind = FindFirstFile(buffer, &dir->nob__private.win32_data);
+    LPCWSTR buffer = nob_win32_temp_utf8_to_utf16(nob_temp_sprintf("%s\\*", dir_path));
+    dir->nob__private.win32_hFind = FindFirstFileW(buffer, &dir->nob__private.win32_data);
     nob_temp_rewind(temp_mark);
 
     if (dir->nob__private.win32_hFind == INVALID_HANDLE_VALUE) {
@@ -1984,17 +2030,17 @@ NOBDEF bool nob_dir_entry_next(Nob_Dir_Entry *dir)
 #ifdef _WIN32
     if (!dir->nob__private.win32_init) {
         dir->nob__private.win32_init = true;
-        dir->name = dir->nob__private.win32_data.cFileName;
+        dir->name = nob_win32_temp_utf16_to_utf8(dir->nob__private.win32_data.cFileName);
         return true;
     }
 
-    if (!FindNextFile(dir->nob__private.win32_hFind, &dir->nob__private.win32_data)) {
+    if (!FindNextFileW(dir->nob__private.win32_hFind, &dir->nob__private.win32_data)) {
         if (GetLastError() == ERROR_NO_MORE_FILES) return false;
         nob_log(NOB_ERROR, "Could not read next directory entry: %s", nob_win32_error_message(GetLastError()));
         dir->error = true;
         return false;
     }
-    dir->name = dir->nob__private.win32_data.cFileName;
+    dir->name = nob_win32_temp_utf16_to_utf8(dir->nob__private.win32_data.cFileName);
 #else
     errno = 0;
     dir->nob__private.posix_ent = readdir(dir->nob__private.posix_dir);

--- a/nob.h
+++ b/nob.h
@@ -2180,7 +2180,7 @@ NOBDEF bool nob_write_entire_file(const char *path, const void *data, size_t siz
     WCHAR utf16_buffer[MAX_PATH];
     int n = MultiByteToWideChar(CP_UTF8, 0, path, -1, utf16_buffer, sizeof(utf16_buffer));
     if(n == 0){
-        nob_log(NOB_ERROR, "Could not convert dir_path name from utf8 to utf16: %s", nob_win32_error_message(GetLastError()));
+        nob_log(NOB_ERROR, "Could not convert file path from utf8 to utf16: %s", nob_win32_error_message(GetLastError()));
         return false;
     }
 
@@ -2528,7 +2528,7 @@ NOBDEF bool nob_read_entire_file(const char *path, Nob_String_Builder *sb)
     WCHAR wpath[MAX_PATH];
     int n = MultiByteToWideChar(CP_UTF8, 0, path, -1, wpath, sizeof(wpath));
     if(n == 0){
-        nob_log(NOB_ERROR, "Could not convert dir_path name from utf8 to utf16: %s", nob_win32_error_message(GetLastError()));
+        nob_log(NOB_ERROR, "Could not convert file path from utf8 to utf16: %s", nob_win32_error_message(GetLastError()));
         return false;
     }
     FILE *f = _wfopen(wpath, L"rb");

--- a/nob.h
+++ b/nob.h
@@ -2752,7 +2752,7 @@ NOBDEF const char *nob_get_current_dir_temp(void)
     int nUtf8BufferLength = WideCharToMultiByte(CP_UTF8, 0, utf16_buffer, nBufferLength, NULL, 0, NULL, NULL);
     if(nUtf8BufferLength == 0){
       nob_log(NOB_ERROR, "Could not determine utf8 path size: %s", nob_win32_error_message(GetLastError()));
-      return false;
+      return NULL;
     }
     
     char* buffer;
@@ -2761,7 +2761,7 @@ NOBDEF const char *nob_get_current_dir_temp(void)
     nUtf8BufferLength = WideCharToMultiByte(CP_UTF8, 0, utf16_buffer, nBufferLength, buffer, nUtf8BufferLength, NULL, NULL);
     if(nBufferLength == 0){
       nob_log(NOB_ERROR, "Could not convert utf16 path to utf8: %s", nob_win32_error_message(GetLastError()));
-      return false;
+      return NULL;
     }
 
 

--- a/nob.h
+++ b/nob.h
@@ -316,6 +316,7 @@ typedef struct {
         WIN32_FIND_DATAW win32_data;
         HANDLE win32_hFind;
         bool win32_init;
+        char utf8_name[MAX_PATH];
 #else
         DIR *posix_dir;
         struct dirent *posix_ent;
@@ -951,7 +952,6 @@ NOBDEF Nob_String_View nob_sv_from_parts(const char *data, size_t count);
 #ifdef _WIN32
 
 NOBDEF char *nob_win32_error_message(DWORD err);
-NOBDEF LPCWSTR nob_win32_temp_utf8_to_utf16(const char* str);
 
 #endif // _WIN32
 
@@ -1014,51 +1014,6 @@ NOBDEF char *nob_win32_error_message(DWORD err) {
 
     return win32ErrMsg;
 }
-
-// https://learn.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-multibytetowidechar
-NOBDEF LPCWSTR nob_win32_temp_utf8_to_utf16(const char* str){
-
-  // n is the output strings size in charachters and includes size for null terminator due to -1
-  int n = MultiByteToWideChar(CP_UTF8, 0, str, -1, NULL, 0);
-  if(n == 0){
-    nob_log(NOB_ERROR, "Could not determine charachter count for utf8 to utf16 conversion: %s", nob_win32_error_message(GetLastError()));
-    return NULL;
-  }
-
-  LPWSTR wstr;
-  wstr = (LPWSTR)nob_temp_alloc(n*sizeof(*wstr));
-
-  n = MultiByteToWideChar(CP_UTF8, 0, str, -1, wstr, n);
-  if(n == 0){
-    nob_log(NOB_ERROR, "Could not convert utf8 to utf16: %s", nob_win32_error_message(GetLastError()));
-    return NULL;
-  }
-
-  return wstr;
-}
-
-// https://learn.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-widechartomultibyte
-NOBDEF const char* nob_win32_temp_utf16_to_utf8(LPCWSTR wstr){
-
-  // n is the output strings size in bytes and includes size for null terminator due to -1
-  int n = WideCharToMultiByte(CP_UTF8, 0, wstr, -1, NULL, 0, NULL, NULL);
-  if(n == 0){
-    nob_log(NOB_ERROR, "Could not determine byte count for utf16 to utf8 conversion: %s", nob_win32_error_message(GetLastError()));
-    return NULL;
-  }
-
-  char* str;
-  str = (char*)nob_temp_alloc(n*sizeof(*str));
-
-  n = WideCharToMultiByte(CP_UTF8, 0, wstr, -1, str, n, NULL, NULL);
-  if(n == 0){
-    nob_log(NOB_ERROR, "Could not convert utf16 to utf8: %s", nob_win32_error_message(GetLastError()));
-    return NULL;
-  }
-
-  return str;
-}
-
 #endif // _WIN32
 
 // The implementation idea is stolen from https://github.com/zhiayang/nabs
@@ -1263,7 +1218,6 @@ static void nob__win32_cmd_quote(Nob_Cmd cmd, Nob_String_Builder *quoted)
         }
     }
 }
-
 #endif
 
 NOBDEF int nob_nprocs(void)
@@ -2005,8 +1959,16 @@ NOBDEF bool nob_dir_entry_open(const char *dir_path, Nob_Dir_Entry *dir)
     memset(dir, 0, sizeof(*dir));
 #ifdef _WIN32
     size_t temp_mark = nob_temp_save();
-    LPCWSTR buffer = nob_win32_temp_utf8_to_utf16(nob_temp_sprintf("%s\\*", dir_path));
-    dir->nob__private.win32_hFind = FindFirstFileW(buffer, &dir->nob__private.win32_data);
+    char *buffer = nob_temp_sprintf("%s\\*", dir_path);
+
+    WCHAR utf16_buffer[MAX_PATH];
+    int n = MultiByteToWideChar(CP_UTF8, 0, buffer, -1, utf16_buffer, sizeof(utf16_buffer));
+    if(n == 0){
+        nob_log(NOB_ERROR, "Could not convert dir_path name from utf8 to utf16: %s", nob_win32_error_message(GetLastError()));
+        return false;
+    }
+
+    dir->nob__private.win32_hFind = FindFirstFileW(utf16_buffer, &dir->nob__private.win32_data);
     nob_temp_rewind(temp_mark);
 
     if (dir->nob__private.win32_hFind == INVALID_HANDLE_VALUE) {
@@ -2030,7 +1992,13 @@ NOBDEF bool nob_dir_entry_next(Nob_Dir_Entry *dir)
 #ifdef _WIN32
     if (!dir->nob__private.win32_init) {
         dir->nob__private.win32_init = true;
-        dir->name = (char*)nob_win32_temp_utf16_to_utf8(dir->nob__private.win32_data.cFileName);
+
+        int n = WideCharToMultiByte(CP_UTF8, 0, dir->nob__private.win32_data.cFileName, -1, dir->nob__private.utf8_name, sizeof(dir->nob__private.utf8_name), NULL, NULL);
+        if(n == 0){
+            nob_log(NOB_ERROR, "Could not convert path name from utf16 to utf8: %s", nob_win32_error_message(GetLastError()));
+            return false;
+        }
+        dir->name = dir->nob__private.utf8_name;
         return true;
     }
 
@@ -2040,7 +2008,13 @@ NOBDEF bool nob_dir_entry_next(Nob_Dir_Entry *dir)
         dir->error = true;
         return false;
     }
-    dir->name = (char*)nob_win32_temp_utf16_to_utf8(dir->nob__private.win32_data.cFileName);
+        
+    int n = WideCharToMultiByte(CP_UTF8, 0, dir->nob__private.win32_data.cFileName, -1, dir->nob__private.utf8_name, sizeof(dir->nob__private.utf8_name), NULL, NULL);
+    if(n == 0){
+      nob_log(NOB_ERROR, "Could not convert path name from utf16 to utf8: %s", nob_win32_error_message(GetLastError()));
+      return false;
+    }
+    dir->name = dir->nob__private.utf8_name;
 #else
     errno = 0;
     dir->nob__private.posix_ent = readdir(dir->nob__private.posix_dir);
@@ -2760,17 +2734,36 @@ NOBDEF int nob_file_exists(const char *file_path)
 NOBDEF const char *nob_get_current_dir_temp(void)
 {
 #ifdef _WIN32
-    DWORD nBufferLength = GetCurrentDirectory(0, NULL);
+    DWORD nBufferLength = GetCurrentDirectoryW(0, NULL);
     if (nBufferLength == 0) {
         nob_log(NOB_ERROR, "could not get current directory: %s", nob_win32_error_message(GetLastError()));
         return NULL;
     }
 
-    char *buffer = (char*) nob_temp_alloc(nBufferLength);
-    if (GetCurrentDirectory(nBufferLength, buffer) == 0) {
+    LPWSTR utf16_buffer;
+    utf16_buffer = (LPWSTR) nob_temp_alloc(nBufferLength*sizeof(*utf16_buffer));
+
+    if (GetCurrentDirectoryW(nBufferLength, utf16_buffer) == 0) {
         nob_log(NOB_ERROR, "could not get current directory: %s", nob_win32_error_message(GetLastError()));
         return NULL;
     }
+
+
+    int nUtf8BufferLength = WideCharToMultiByte(CP_UTF8, 0, utf16_buffer, nBufferLength, NULL, 0, NULL, NULL);
+    if(nUtf8BufferLength == 0){
+      nob_log(NOB_ERROR, "Could not determine utf8 path size: %s", nob_win32_error_message(GetLastError()));
+      return false;
+    }
+    
+    char* buffer;
+    buffer = (char*) nob_temp_alloc(nUtf8BufferLength*sizeof(*buffer));
+    
+    nUtf8BufferLength = WideCharToMultiByte(CP_UTF8, 0, utf16_buffer, nBufferLength, buffer, nUtf8BufferLength, NULL, NULL);
+    if(nBufferLength == 0){
+      nob_log(NOB_ERROR, "Could not convert utf16 path to utf8: %s", nob_win32_error_message(GetLastError()));
+      return false;
+    }
+
 
     return buffer;
 #else

--- a/nob.h
+++ b/nob.h
@@ -1026,7 +1026,7 @@ NOBDEF LPCWSTR nob_win32_temp_utf8_to_utf16(const char* str){
   }
 
   LPWSTR wstr;
-  wstr = nob_temp_alloc(n*sizeof(*wstr));
+  wstr = (LPWSTR)nob_temp_alloc(n*sizeof(*wstr));
 
   n = MultiByteToWideChar(CP_UTF8, 0, str, -1, wstr, n);
   if(n == 0){
@@ -1048,7 +1048,7 @@ NOBDEF const char* nob_win32_temp_utf16_to_utf8(LPCWSTR wstr){
   }
 
   char* str;
-  str = nob_temp_alloc(n*sizeof(*str));
+  str = (char*)nob_temp_alloc(n*sizeof(*str));
 
   n = WideCharToMultiByte(CP_UTF8, 0, wstr, -1, str, n, NULL, NULL);
   if(n == 0){

--- a/nob.h
+++ b/nob.h
@@ -308,7 +308,7 @@ NOBDEF bool nob_walk_dir_opt(const char *root, Nob_Walk_Func func, Nob_Walk_Dir_
 #define nob_walk_dir(root, func, ...) nob_walk_dir_opt((root), (func), NOB_CLIT(Nob_Walk_Dir_Opt){__VA_ARGS__})
 
 typedef struct {
-    const char *name;
+    char *name;
     bool error;
 
     struct {
@@ -2030,7 +2030,7 @@ NOBDEF bool nob_dir_entry_next(Nob_Dir_Entry *dir)
 #ifdef _WIN32
     if (!dir->nob__private.win32_init) {
         dir->nob__private.win32_init = true;
-        dir->name = nob_win32_temp_utf16_to_utf8(dir->nob__private.win32_data.cFileName);
+        dir->name = (char*)nob_win32_temp_utf16_to_utf8(dir->nob__private.win32_data.cFileName);
         return true;
     }
 
@@ -2040,7 +2040,7 @@ NOBDEF bool nob_dir_entry_next(Nob_Dir_Entry *dir)
         dir->error = true;
         return false;
     }
-    dir->name = nob_win32_temp_utf16_to_utf8(dir->nob__private.win32_data.cFileName);
+    dir->name = (char*)nob_win32_temp_utf16_to_utf8(dir->nob__private.win32_data.cFileName);
 #else
     errno = 0;
     dir->nob__private.posix_ent = readdir(dir->nob__private.posix_dir);


### PR DESCRIPTION
I added:
- The `char utf8_name[MAX_PATH]` buffer inside Nob_Dir_Entry.nob__private.

I changed:
- `FindFirstFile` inside `nob_dir_entry_open` to `FindFirstFileW`.
- `FindNextFile` inside `nob_dir_entry_next` to `FindNextFileW`.
- `WIN32_FIND_DATA` inside `Nob_Dir_Entry.nob__private` to `WIN32_FIND_DATAW`.
- `GetCurrentDirectory` inside `nob_get_current_dir_temp` with `GetCurrentDirectoryW`.

I tried to keep the memory allocation consistent with the previous behaviour.
So inside `get_current_dir_temp()` I use the temp allocator for a temporary utf16 buffer, but in the nob_dir_entry functions it uses a the new `utf8_name` buffer which takes the place of the `WIN32_FIND_DATAA.cFileName` buffer.

This has the disadvantage that valid file names might not fit inside this new buffer but I think this is a decent compromise as opposed to requiring the use of the temp allocator for example.

To validate that this works I wrote quick little test:

```c
#if 0
cc -Wall -Wextra -Werror -g -o app main.c && ./app
exit 0
#endif

#define NOB_IMPLEMENTATION
#include "nob.h"

int main(void){
  nob_log(NOB_INFO, "current_dir: %s", nob_get_current_dir_temp());
  File_Paths paths = {0};
  assert(read_entire_dir(".", &paths));
  da_foreach(const char*, path, &paths){
    const unsigned char* p = (const unsigned char*) *path;
    fprintf(stderr, "%s", p);
    fprintf(stderr, "\n");
    while(*p != '\0'){
      fprintf(stderr, "%02X ", *p);
      p++;
    }
    fprintf(stderr, "\n");
  }
  return 0;
}
```

Here is the result before the change:
```sh
[INFO] current_dir: C:\msys64\tmp\test_path\t
.
2E
..
2E 2E
app.exe
61 70 70 2E 65 78 65
main.c
6D 61 69 6E 2E 63
nob.h
6E 6F 62 2E 68
t
74 EA 73 74
```

Here is the result after the change:
```sh
[INFO] current_dir: C:\msys64\tmp\test_path\têst
.
2E
..
2E 2E
app.exe
61 70 70 2E 65 78 65
main.c
6D 61 69 6E 2E 63
nob.h
6E 6F 62 2E 68
têst
74 C3 AA 73 74
```