### PR TITLE
Fix warning when building with -O3

### DIFF
--- a/nob.h
+++ b/nob.h
@@ -2497,7 +2497,7 @@ NOBDEF bool nob_read_entire_file(const char *path, Nob_String_Builder *sb)
         sb->capacity = new_count;
     }
 
-    fread(sb->items + sb->count, m, 1, f);
+    size_t const nread = fread(sb->items + sb->count, m, 1, f);
     if (ferror(f)) {
         // TODO: Afaik, ferror does not set errno. So the error reporting in defer is not correct in this case.
         nob_return_defer(false);


### PR DESCRIPTION
```
nob.h: In function ‘nob_read_entire_file’:
nob.h:1676:5: warning: ignoring return value of ‘fread’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
 1676 |     fread(sb->items + sb->count, m, 1, f);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```