### PR TITLE
Make nob_default_handler work in multi-threaded or multi-process

### DIFF
--- a/nob.h
+++ b/nob.h
@@ -1899,23 +1899,26 @@ NOBDEF void nob_default_log_handler(Nob_Log_Level level, const char *fmt, va_lis
 {
     if (level < nob_minimal_log_level) return;
 
+    char *prefix = NULL;
     switch (level) {
     case NOB_INFO:
-        fprintf(stderr, "[INFO] ");
+        prefix = "[INFO] ";
         break;
     case NOB_WARNING:
-        fprintf(stderr, "[WARNING] ");
+        prefix = "[WARNING] ";
         break;
     case NOB_ERROR:
-        fprintf(stderr, "[ERROR] ");
+        prefix = "[ERROR] ";
         break;
     case NOB_NO_LOGS: return;
     default:
         NOB_UNREACHABLE("Nob_Log_Level");
     }
 
-    vfprintf(stderr, fmt, args);
-    fprintf(stderr, "\n");
+    size_t mark = nob_temp_save();
+    char *msg = nob_temp_vsprintf(fmt, args);
+    fprintf(stderr, "%s%s\n", prefix, msg);
+    nob_temp_rewind(mark);
 }
 
 NOBDEF void nob_null_log_handler(Nob_Log_Level level, const char *fmt, va_list args)


### PR DESCRIPTION
The old implementation of `nob_default_handler` works well in a single‑threaded environment, but it may produce unexpected output in a multi‑process environment. For example, the following output is generated in my project:

```console
[ERROR] [ERROR] [ERROR] Could not read file ../tests/if_else.mus.out: No such file or directoryCould not read file ../tests/invoke_extern.mus.out: No such file or directoryCould not read file ../tests/binop.mus.out: No such file or directory
```

This happens because `nob_default_handler` invokes `fprintf` multiple times, and another process may print something else between the multiple `fprintf` calls inside `nob_default_handler`.

To fix this issue, I use `nob_temp_svprintf` to generate the complete message first, and then print it with a single `fprintf` call.