### PR TITLE
added format argument to NOB_TODOF and NOB_UNREACHABLEF

### DIFF
--- a/nob.h
+++ b/nob.h
@@ -207,9 +207,9 @@ NOBDEF void nob__panicf(const char *file, int line, const char *label, const cha
 
 #define NOB_UNUSED(value) (void)(value)
 #define NOB_TODO(message) do { fprintf(stderr, "%s:%d: TODO: %s\n", __FILE__, __LINE__, message); abort(); } while(0)
-#define NOB_TODOF(...) nob__panicf(__FILE__, __LINE__, "TODO", __VA_ARGS__)
+#define NOB_TODOF(format, ...) nob__panicf(__FILE__, __LINE__, "TODO", format, ## __VA_ARGS__)
 #define NOB_UNREACHABLE(message) do { fprintf(stderr, "%s:%d: UNREACHABLE: %s\n", __FILE__, __LINE__, message); abort(); } while(0)
-#define NOB_UNREACHABLEF(...) nob__panicf(__FILE__, __LINE__, "UNREACHABLE", __VA_ARGS__)
+#define NOB_UNREACHABLEF(format, ...) nob__panicf(__FILE__, __LINE__, "UNREACHABLE", format, ## __VA_ARGS__)
 
 #define NOB_ARRAY_LEN(array) (sizeof(array)/sizeof(array[0]))
 #define NOB_ARRAY_GET(array, index) \


### PR DESCRIPTION
Adds a `format` argument to `NOB_TODOF` and `NOB_UNREACHABLEF` to make the signature of those a bit more clear.

the previous issue with explicitly adding a format string was that it would break when not giving any other arguments due to a trailing `,` (only for some compilers/versions?).

with the token concatenation (as seen in the diff), when `__VA_ARGS__` is empty, the token toncatenation 'fails' and also removes the comma.

i did a liddle test to confirm its working, seems to be all good. tested with no argument, only format, and other arguments.