### PR TITLE
Use nob.c as an example of C compatible shebang for Linux.

### DIFF
--- a/nob.c
+++ b/nob.c
@@ -1,3 +1,5 @@
+//usr/bin/env -S cc -Wall -Og -g $0 -o nob; ./nob $@; exit
+
 #include "shared.h"
 
 const char *test_names[] = {


### PR DESCRIPTION
## Motivation
For me `nob.c` is more than a test suite, it's an example for users of `nob.h`, as this double slash feature is underappreciated it would be great to share this to the users.
## Where it works
This should only work with an `env` executable that is located in `/usr/bin` and supports the `-S` flag on OSes that support the double forward slash as a shebang (This feature is implemented on recent Linux kernels). On other cases this should be ignored as a comment or cause an indecipherable error.
## How the shebang works
Upon execution the Kernel Program Loader will parse the double slash and find the program starting from the root directory, if found it will execute it, the rest of the work is on `env` that parses the executed line and create a valid command to pass to the shell.
Sorry if something on this explanation is missing, I did this PR in a hurry.