### PR TITLE
Fix nob_read_entire_file for procfs files and pipes

### DIFF
--- a/nob.c
+++ b/nob.c
@@ -5,6 +5,7 @@ const char *test_names[] = {
     "cmd_redirect",
     "cmd_args_passing",
     "read_entire_dir",
+    "read_entire_file",
     "da_resize",
     "da_last",
     "da_remove_unordered",

--- a/nob.h
+++ b/nob.h
@@ -2564,36 +2564,42 @@ NOBDEF bool nob_rename(const char *old_path, const char *new_path)
 NOBDEF bool nob_read_entire_file(const char *path, Nob_String_Builder *sb)
 {
     bool result = true;
+    size_t saved_count = sb->count;
+    long long m = 0;
 
     FILE *f = fopen(path, "rb");
-    size_t new_count = 0;
-    long long m = 0;
-    if (f == NULL)                 nob_return_defer(false);
-    if (fseek(f, 0, SEEK_END) < 0) nob_return_defer(false);
+    if (f == NULL) nob_return_defer(false);
+
+    if (fseek(f, 0, SEEK_END) == 0) {
 #ifndef _WIN32
-    m = ftell(f);
+        m = ftell(f);
 #else
-    m = _telli64(_fileno(f));
+        m = _telli64(_fileno(f));
 #endif
-    if (m < 0)                     nob_return_defer(false);
-    if (fseek(f, 0, SEEK_SET) < 0) nob_return_defer(false);
-
-    new_count = sb->count + m;
-    if (new_count > sb->capacity) {
-        sb->items = NOB_DECLTYPE_CAST(sb->items)NOB_REALLOC(sb->items, new_count);
-        NOB_ASSERT(sb->items != NULL && "Buy more RAM lool!!");
-        sb->capacity = new_count;
+        if (fseek(f, 0, SEEK_SET) < 0) nob_return_defer(false);
+        if (m > 0) nob_da_reserve(sb, sb->count + (size_t)m);
+    } else {
+        clearerr(f);
     }
 
-    fread(sb->items + sb->count, m, 1, f);
-    if (ferror(f)) {
-        // TODO: Afaik, ferror does not set errno. So the error reporting in defer is not correct in this case.
-        nob_return_defer(false);
+    for (;;) {
+        nob_da_reserve(sb, sb->count + 1);
+        size_t n = fread(sb->items + sb->count, 1, sb->capacity - sb->count, f);
+        sb->count += n;
+        if (n == 0) {
+            if (ferror(f)) {
+                // TODO: Afaik, ferror does not set errno. So the error reporting in defer is not correct in this case.
+                nob_return_defer(false);
+            }
+            break;
+        }
     }
-    sb->count = new_count;
 
 defer:
-    if (!result) nob_log(NOB_ERROR, "Could not read file %s: %s", path, strerror(errno));
+    if (!result) {
+        sb->count = saved_count;
+        nob_log(NOB_ERROR, "Could not read file %s: %s", path, strerror(errno));
+    }
     if (f) fclose(f);
     return result;
 }

--- a/tests/read_entire_file.c
+++ b/tests/read_entire_file.c
@@ -1,0 +1,50 @@
+#include "shared.h"
+
+size_t error_counter = 0;
+
+void error_counting_log_handler(Nob_Log_Level level, const char *fmt, va_list args)
+{
+    UNUSED(fmt);
+    UNUSED(args);
+    if (level == ERROR) error_counter++;
+}
+
+int main(void)
+{
+    String_Builder sb = {0};
+
+    const char *payload = "first line\nsecond line\n";
+    if (!write_entire_file("file.txt", payload, strlen(payload))) return 1;
+    if (!read_entire_file("file.txt", &sb)) return 1;
+    printf("regular file: read %zu bytes\n", sb.count);
+    printf("%.*s", (int)sb.count, sb.items);
+
+    if (!read_entire_file("file.txt", &sb)) return 1;
+    printf("read again: %zu bytes total\n", sb.count);
+
+    Nob_Log_Handler *saved_log_handler = get_log_handler();
+    set_log_handler(error_counting_log_handler);
+    bool ok = read_entire_file("does-not-exist.txt", &sb);
+    set_log_handler(saved_log_handler);
+    printf("missing file: ok=%s, error_counter=%zu, count=%zu\n", ok ? "true" : "false", error_counter, sb.count);
+
+#ifndef _WIN32
+    if (mkfifo("fifo", 0644) < 0) return 1;
+    pid_t pid = fork();
+    if (pid < 0) return 1;
+    if (pid == 0) {
+        FILE *f = fopen("fifo", "wb");
+        if (f == NULL) _exit(1);
+        fputs("hello through a fifo\n", f);
+        fclose(f);
+        _exit(0);
+    }
+    sb.count = 0;
+    if (!read_entire_file("fifo", &sb)) return 1;
+    if (waitpid(pid, NULL, 0) < 0) return 1;
+    printf("fifo: read %zu bytes\n", sb.count);
+    printf("%.*s", (int)sb.count, sb.items);
+#endif
+
+    return 0;
+}

--- a/tests/read_entire_file.stdout.txt
+++ b/tests/read_entire_file.stdout.txt
@@ -1,0 +1,7 @@
+regular file: read 23 bytes
+first line
+second line
+read again: 46 bytes total
+missing file: ok=false, error_counter=1, count=46
+fifo: read 21 bytes
+hello through a fifo

--- a/tests/read_entire_file.win32.stdout.txt
+++ b/tests/read_entire_file.win32.stdout.txt
@@ -1,0 +1,5 @@
+regular file: read 23 bytes
+first line
+second line
+read again: 46 bytes total
+missing file: ok=false, error_counter=1, count=46


### PR DESCRIPTION
Fixes #242

`nob_read_entire_file` gets the file size via `fseek`/`ftell` and then reads exactly that many bytes. Files on virtual file systems like procfs report size 0, so the function "succeeds" but the string builder stays empty:

```c
#define NOB_IMPLEMENTATION
#include "nob.h"

int main(void)
{
    Nob_String_Builder sb = {0};
    if (!nob_read_entire_file("/proc/version", &sb)) return 1;
    printf("read %zu bytes\n", sb.count);
    return 0;
}
```

```console
$ ./main
read 0 bytes
```

Pipes and FIFOs are worse, `fseek` fails on them so you cannot read them at all:

```console
[ERROR] Could not read file pipe: Illegal seek
```

The patch keeps the `fseek`/`ftell` size but only as a hint to preallocate the string builder. The actual reading is a `fread` loop until EOF, so the real content ends up in the builder no matter what size was reported. If the file is not seekable the preallocation is simply skipped. On failure `sb->count` is restored, so a failed read does not leave partial content in the builder, which matches the old behavior of not touching `count` on errors.

After the patch:

```console
$ ./main
read 168 bytes
```

I also added `tests/read_entire_file.c` which covers regular files, appending to a non empty builder, a missing file, and reading from a FIFO (that last part is skipped on Windows).

Tested on Linux (gcc 14, both C and C++ mode) and macOS (clang), the whole test suite passes on both. One note: reading endless files like `/dev/zero` now keeps reading forever instead of returning an empty builder, but that is the same thing `cat` does.
