### PR TITLE
Fix dead nob_get_file_type error checks

### DIFF
--- a/nob.c
+++ b/nob.c
@@ -5,6 +5,7 @@ const char *test_names[] = {
     "cmd_redirect",
     "cmd_args_passing",
     "read_entire_dir",
+    "get_file_type",
     "da_resize",
     "da_last",
     "da_remove_unordered",

--- a/nob.h
+++ b/nob.h
@@ -2119,7 +2119,7 @@ bool nob__walk_dir_opt_impl(Nob_String_Builder *file_path, Nob_Walk_Func func, s
     Nob_Walk_Action action = NOB_WALK_CONT;
 
     Nob_File_Type file_type = nob_get_file_type(file_path->items);
-    if (file_type < 0) nob_return_defer(false);
+    if (file_type == (Nob_File_Type)-1) nob_return_defer(false);
 
     // Pre-order walking
     if (!opt.post_order) {
@@ -2325,7 +2325,7 @@ NOBDEF bool nob_copy_directory_recursively(const char *src_path, const char *dst
     size_t temp_checkpoint = nob_temp_save();
 
     Nob_File_Type type = nob_get_file_type(src_path);
-    if (type < 0) return false;
+    if (type == (Nob_File_Type)-1) return false;
 
     switch (type) {
         case NOB_FILE_DIRECTORY: {

--- a/tests/get_file_type.c
+++ b/tests/get_file_type.c
@@ -1,0 +1,42 @@
+#include "shared.h"
+
+size_t error_counter = 0;
+
+void error_counting_log_handler(Nob_Log_Level level, const char *fmt, va_list args)
+{
+    UNUSED(fmt);
+    UNUSED(args);
+    if (level == ERROR) error_counter++;
+}
+
+bool walk_noop(Nob_Walk_Entry entry)
+{
+    UNUSED(entry);
+    return true;
+}
+
+int main(void)
+{
+    const char *missing = "definitely-does-not-exist-42";
+
+    Nob_Log_Handler *saved_log_handler = get_log_handler();
+    set_log_handler(error_counting_log_handler);
+
+    error_counter = 0;
+    File_Type type = get_file_type(missing);
+    printf("get_file_type(missing): is_error=%s, error_counter=%zu\n",
+           type == (File_Type)-1 ? "true" : "false", error_counter);
+
+    error_counter = 0;
+    bool walk_ok = walk_dir(missing, walk_noop);
+    printf("walk_dir(missing): ok=%s, error_counter=%zu\n",
+           walk_ok ? "true" : "false", error_counter);
+
+    error_counter = 0;
+    bool copy_ok = copy_directory_recursively(missing, "some-dst");
+    printf("copy_directory_recursively(missing): ok=%s, error_counter=%zu\n",
+           copy_ok ? "true" : "false", error_counter);
+
+    set_log_handler(saved_log_handler);
+    return 0;
+}

--- a/tests/get_file_type.stdout.txt
+++ b/tests/get_file_type.stdout.txt
@@ -1,0 +1,3 @@
+get_file_type(missing): is_error=true, error_counter=1
+walk_dir(missing): ok=false, error_counter=1
+copy_directory_recursively(missing): ok=false, error_counter=1

--- a/tests/get_file_type.win32.stdout.txt
+++ b/tests/get_file_type.win32.stdout.txt
@@ -1,0 +1,3 @@
+get_file_type(missing): is_error=true, error_counter=1
+walk_dir(missing): ok=false, error_counter=1
+copy_directory_recursively(missing): ok=false, error_counter=1


### PR DESCRIPTION
Fix for #262. The two `if (type < 0)` checks compare an unsigned enum, so they never fire. Changed them to compare against `(Nob_File_Type)-1` directly. Also added a test covering these error paths.