### PR TITLE
Correct Nob_Cmd_Opt documentation

### DIFF
--- a/nob.h
+++ b/nob.h
@@ -532,7 +532,7 @@ typedef struct {
 typedef struct {
     // Run the command asynchronously appending its Nob_Proc to the provided Nob_Procs array
     Nob_Procs *async;
-    // Maximum processes allowed in the .async list. Zero implies nob_nprocs().
+    // Maximum processes allowed in the .async list. Zero implies nob_nprocs() + 1.
     size_t max_procs;
     // Do not reset the command after execution.
     bool dont_reset;


### PR DESCRIPTION
source: 
```c
NOBDEF bool nob_cmd_run_opt(Nob_Cmd *cmd, Nob_Cmd_Opt opt)
{
    bool result = true;
    Nob_Fd fdin  = NOB_INVALID_FD;
    Nob_Fd fdout = NOB_INVALID_FD;
    Nob_Fd fderr = NOB_INVALID_FD;
    Nob_Fd *opt_fdin  = NULL;
    Nob_Fd *opt_fdout = NULL;
    Nob_Fd *opt_fderr = NULL;
    Nob_Proc proc = NOB_INVALID_PROC;

    size_t max_procs = opt.max_procs > 0 ? opt.max_procs : (size_t) nob_nprocs() + 1; // line 1325

	// (...) rest of the code
}
```